### PR TITLE
[1.6.0] Wand Storage + Player Centered Config

### DIFF
--- a/BuildersWand/build.gradle
+++ b/BuildersWand/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'dev.heypr'
-version = '1.5.1-b' + (System.getenv("BUILD_NUMBER") ?: "DEV")
+version = '1.6.0-b' + (System.getenv("BUILD_NUMBER") ?: "DEV")
 
 repositories {
     mavenCentral()
@@ -37,6 +37,7 @@ dependencies {
     compileOnly("com.github.angeschossen:LandsAPI:7.15.4")
     compileOnly("world.bentobox:bentobox:3.1.1-SNAPSHOT")
     implementation("com.zaxxer:HikariCP:7.0.2")
+    implementation("commons-codec:commons-codec:1.5")
     implementation project(":api")
 }
 

--- a/BuildersWand/build.gradle
+++ b/BuildersWand/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.13")
     compileOnly("com.github.angeschossen:LandsAPI:7.15.4")
     compileOnly("world.bentobox:bentobox:3.1.1-SNAPSHOT")
+    compileOnly("commons-codec:commons-codec:1.5")
     implementation("com.zaxxer:HikariCP:7.0.2")
-    implementation("commons-codec:commons-codec:1.5")
     implementation project(":api")
 }
 

--- a/BuildersWand/build.gradle
+++ b/BuildersWand/build.gradle
@@ -35,7 +35,8 @@ dependencies {
     compileOnly("com.bgsoftware:SuperiorSkyblockAPI:2024.4")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.13")
     compileOnly("com.github.angeschossen:LandsAPI:7.15.4")
-    compileOnly ("world.bentobox:bentobox:3.1.1-SNAPSHOT")
+    compileOnly("world.bentobox:bentobox:3.1.1-SNAPSHOT")
+    implementation("com.zaxxer:HikariCP:7.0.2")
     implementation project(":api")
 }
 

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
@@ -3,17 +3,20 @@ package dev.heypr.buildersWand;
 import dev.heypr.buildersWand.api.BuildersWandAPI;
 import dev.heypr.buildersWand.commands.BuildersWandCommand;
 import dev.heypr.buildersWand.impl.ApiImplementation;
-import dev.heypr.buildersWand.listeners.WandListener;
+import dev.heypr.buildersWand.listeners.CraftListener;
+import dev.heypr.buildersWand.listeners.FurnaceListener;
+import dev.heypr.buildersWand.listeners.WandStorageListener;
+import dev.heypr.buildersWand.listeners.WandUseListener;
 import dev.heypr.buildersWand.managers.RecipeManager;
 import dev.heypr.buildersWand.managers.WandManager;
 import dev.heypr.buildersWand.managers.io.ConfigManager;
 import dev.heypr.buildersWand.managers.io.MessageManager;
 import dev.heypr.buildersWand.metrics.Metrics;
-import dev.heypr.buildersWand.utility.Util;
+import dev.heypr.buildersWand.utility.ComponentUtil;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class BuildersWand extends JavaPlugin {
@@ -29,29 +32,40 @@ public class BuildersWand extends JavaPlugin {
     @SuppressWarnings("UnstableApiUsage")
     public void onEnable() {
         instance = this;
-        PDC_KEY_ID = new NamespacedKey(this, "builders_wand_id");
-        PDC_KEY_DURABILITY = new NamespacedKey(this, "builders_wand_durability");
-        PDC_KEY_UUID = new NamespacedKey(this, "builders_wand_uuid");
-        PDC_KEY_MAX_SIZE = new NamespacedKey(this, "builders_wand_max_size");
-        recipeManager = new RecipeManager(this);
+        PDC_KEY_ID = new NamespacedKey(instance, "builders_wand_id");
+        PDC_KEY_DURABILITY = new NamespacedKey(instance, "builders_wand_durability");
+        PDC_KEY_UUID = new NamespacedKey(instance, "builders_wand_uuid");
+        PDC_KEY_MAX_SIZE = new NamespacedKey(instance, "builders_wand_max_size");
+        recipeManager = new RecipeManager(instance);
         BuildersWand.getWandManager().registerWands();
         MessageManager.initialize();
         ConfigManager.load();
-        BuildersWandAPI.setInstance(new ApiImplementation(this));
-        Bukkit.getPluginManager().registerEvents(new WandListener(), this);
+        registerEvents();
+        BuildersWandAPI.setInstance(new ApiImplementation(instance));
         this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
             final Commands commands = event.registrar();
             new BuildersWandCommand().register(commands);
         });
-        new Metrics(this, 27729);
-        Updater.start(this);
-        Util.log("BuildersWand enabled!");
+        new Metrics(instance, 27729);
+        Updater.start(instance);
+        ComponentUtil.log("BuildersWand enabled!");
     }
 
     @Override
     public void onDisable() {
         Updater.stop();
-        Util.log("BuildersWand disabled.");
+        ComponentUtil.log("BuildersWand disabled.");
+    }
+
+    private void registerEvents() {
+        register(new WandUseListener());
+        register(new CraftListener());
+        register(new FurnaceListener());
+        register(new WandStorageListener());
+    }
+
+    private void register(Listener listener) {
+        instance.getServer().getPluginManager().registerEvents(listener, instance);
     }
 
     public static BuildersWand getInstance() {
@@ -67,18 +81,18 @@ public class BuildersWand extends JavaPlugin {
     }
 
     public static boolean isSuperiorSkyblockEnabled() {
-        return Bukkit.getPluginManager().isPluginEnabled("SuperiorSkyblock2");
+        return instance.getServer().getPluginManager().isPluginEnabled("SuperiorSkyblock2");
     }
 
     public static boolean isBentoBoxEnabled() {
-        return Bukkit.getPluginManager().isPluginEnabled("BentoBox");
+        return instance.getServer().getPluginManager().isPluginEnabled("BentoBox");
     }
 
     public static boolean isWorldGuardEnabled() {
-        return Bukkit.getPluginManager().isPluginEnabled("WorldGuard");
+        return instance.getServer().getPluginManager().isPluginEnabled("WorldGuard");
     }
 
     public static boolean isLandsEnabled() {
-        return Bukkit.getPluginManager().isPluginEnabled("Lands");
+        return instance.getServer().getPluginManager().isPluginEnabled("Lands");
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
@@ -9,6 +9,7 @@ import dev.heypr.buildersWand.listeners.WandStorageListener;
 import dev.heypr.buildersWand.listeners.WandUseListener;
 import dev.heypr.buildersWand.managers.RecipeManager;
 import dev.heypr.buildersWand.managers.WandManager;
+import dev.heypr.buildersWand.managers.WandStorageManager;
 import dev.heypr.buildersWand.managers.io.ConfigManager;
 import dev.heypr.buildersWand.managers.io.MessageManager;
 import dev.heypr.buildersWand.metrics.Metrics;
@@ -22,7 +23,9 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class BuildersWand extends JavaPlugin {
     private static final WandManager wandManager = new WandManager();
     private static RecipeManager recipeManager;
+    private static WandStorageManager storageManager;
     private static BuildersWand instance;
+
     public static NamespacedKey PDC_KEY_ID;
     public static NamespacedKey PDC_KEY_DURABILITY;
     public static NamespacedKey PDC_KEY_MAX_SIZE;
@@ -37,9 +40,13 @@ public class BuildersWand extends JavaPlugin {
         PDC_KEY_UUID = new NamespacedKey(instance, "builders_wand_uuid");
         PDC_KEY_MAX_SIZE = new NamespacedKey(instance, "builders_wand_max_size");
         recipeManager = new RecipeManager(instance);
-        BuildersWand.getWandManager().registerWands();
+        storageManager = new WandStorageManager(instance);
+        storageManager.createTables();
+        storageManager.load();
+        wandManager.registerWands();
         MessageManager.initialize();
         ConfigManager.load();
+        storageManager.startAutosave();
         registerEvents();
         BuildersWandAPI.setInstance(new ApiImplementation(instance));
         this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
@@ -54,6 +61,10 @@ public class BuildersWand extends JavaPlugin {
     @Override
     public void onDisable() {
         Updater.stop();
+        if (storageManager != null) {
+            storageManager.save();
+            storageManager.close();
+        }
         ComponentUtil.log("BuildersWand disabled.");
     }
 
@@ -78,6 +89,10 @@ public class BuildersWand extends JavaPlugin {
 
     public static RecipeManager getRecipeManager() {
         return recipeManager;
+    }
+
+    public static WandStorageManager getStorageManager() {
+        return storageManager;
     }
 
     public static boolean isSuperiorSkyblockEnabled() {

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
@@ -41,12 +41,10 @@ public class BuildersWand extends JavaPlugin {
         PDC_KEY_MAX_SIZE = new NamespacedKey(instance, "builders_wand_max_size");
         recipeManager = new RecipeManager(instance);
         storageManager = new WandStorageManager(instance);
-        storageManager.createTables();
-        storageManager.load();
         wandManager.registerWands();
+        storageManager.init();
         MessageManager.initialize();
         ConfigManager.load();
-        storageManager.startAutosave();
         registerEvents();
         BuildersWandAPI.setInstance(new ApiImplementation(instance));
         this.getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
@@ -62,15 +60,7 @@ public class BuildersWand extends JavaPlugin {
     public void onDisable() {
         Updater.stop();
         if (storageManager != null) {
-            storageManager.stopAutosave();
-            try {
-                storageManager.save();
-            }
-            catch (Exception e) {
-                getLogger().severe("CRITICAL: Could not save wand data during shutdown!");
-                e.printStackTrace();
-            }
-            storageManager.close();
+            storageManager.shutdown();
         }
         ComponentUtil.log("BuildersWand disabled.");
     }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/BuildersWand.java
@@ -62,7 +62,14 @@ public class BuildersWand extends JavaPlugin {
     public void onDisable() {
         Updater.stop();
         if (storageManager != null) {
-            storageManager.save();
+            storageManager.stopAutosave();
+            try {
+                storageManager.save();
+            }
+            catch (Exception e) {
+                getLogger().severe("CRITICAL: Could not save wand data during shutdown!");
+                e.printStackTrace();
+            }
             storageManager.close();
         }
         ComponentUtil.log("BuildersWand disabled.");

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/Updater.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/Updater.java
@@ -2,7 +2,7 @@ package dev.heypr.buildersWand;
 
 import dev.heypr.buildersWand.managers.io.ConfigManager;
 import dev.heypr.buildersWand.managers.io.MessageManager;
-import dev.heypr.buildersWand.utility.Util;
+import dev.heypr.buildersWand.utility.ComponentUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
@@ -28,7 +28,7 @@ public class Updater {
         long intervalTicks = intervalMinutes * 60L * 20L;
         Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> checkAndNotify(plugin));
         task = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> checkAndNotify(plugin), intervalTicks, intervalTicks);
-        Util.log("Updater started. Checking every " + intervalMinutes + " minutes.");
+        ComponentUtil.log("Updater started. Checking every " + intervalMinutes + " minutes.");
     }
 
     public static void stop() {
@@ -51,12 +51,12 @@ public class Updater {
                 Bukkit.getScheduler().runTask(plugin, () -> notifyUpdateAvailable(plugin, current, latest));
             }
             else {
-                Bukkit.getScheduler().runTask(plugin, () -> Util.log("Plugin is up to date!"));
+                Bukkit.getScheduler().runTask(plugin, () -> ComponentUtil.log("Plugin is up to date!"));
             }
         }
         catch (Exception e) {
-            Util.error("Updater error: " + e.getMessage());
-            Util.log("Updater exception: " + e);
+            ComponentUtil.error("Updater error: " + e.getMessage());
+            ComponentUtil.log("Updater exception: " + e);
         }
     }
 
@@ -120,7 +120,7 @@ public class Updater {
         boolean updateInGame = ConfigManager.notifyUpdateInGame();
         String consoleText = String.format("&aUpdate available! &c%s -> &a%s (https://www.spigotmc.org/resources/builderswand.125977)", current, latest);
         if (updateInConsole) {
-            Util.log(consoleText);
+            ComponentUtil.log(consoleText);
         }
         if (updateInGame) {
             String permission = "builderswand.update.notify";

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/CraftListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/CraftListener.java
@@ -1,0 +1,31 @@
+package dev.heypr.buildersWand.listeners;
+
+import dev.heypr.buildersWand.managers.WandManager;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.CrafterCraftEvent;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class CraftListener implements Listener {
+
+    @EventHandler
+    public void onCraft(PrepareItemCraftEvent event) {
+        for (ItemStack item : event.getInventory().getMatrix()) {
+            if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
+                event.getInventory().setResult(null);
+                break;
+            }
+        }
+    }
+
+    @EventHandler
+    public void onCrafterCraft(CrafterCraftEvent event) {
+        ItemStack item = event.getResult();
+        if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
+            event.setResult(new ItemStack(Material.AIR));
+            event.setCancelled(true);
+        }
+    }
+}

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/FurnaceListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/FurnaceListener.java
@@ -1,0 +1,28 @@
+package dev.heypr.buildersWand.listeners;
+
+import dev.heypr.buildersWand.managers.WandManager;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.FurnaceBurnEvent;
+import org.bukkit.event.inventory.FurnaceSmeltEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class FurnaceListener implements Listener {
+
+    @EventHandler
+    public void onFurnaceBurn(FurnaceBurnEvent event) {
+        ItemStack item = event.getFuel();
+        if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
+            event.setConsumeFuel(false);
+            event.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void onFurnaceSmelt(FurnaceSmeltEvent event) {
+        ItemStack item = event.getResult();
+        if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
@@ -24,12 +24,17 @@ public class WandStorageListener implements Listener {
         if (!(event.getView().getTopInventory().getHolder() instanceof WandStorage storage)) return;
         if (!(event.getWhoClicked() instanceof Player player)) return;
 
-        event.setCancelled(true);
         int slot = event.getRawSlot();
 
         switch (slot) {
-            case PREV_BUTTON -> storage.open(player, storage.getCurrentPage() - 1);
-            case NEXT_BUTTON -> storage.open(player, storage.getCurrentPage() + 1);
+            case PREV_BUTTON -> {
+                event.setCancelled(true);
+                storage.open(player, storage.getCurrentPage() - 1);
+            }
+            case NEXT_BUTTON -> {
+                event.setCancelled(true);
+                storage.open(player, storage.getCurrentPage() + 1);
+            }
             default -> {
                 if (slot >= 0 && slot < PAGE_SIZE) {
                     handleItemWithdraw(storage, player, event, slot);

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
@@ -1,7 +1,99 @@
 package dev.heypr.buildersWand.listeners;
 
+import dev.heypr.buildersWand.BuildersWand;
+import dev.heypr.buildersWand.managers.WandStorage;
+import dev.heypr.buildersWand.managers.WandStorageManager;
+import dev.heypr.buildersWand.utility.ComponentUtil;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Map;
 
 public class WandStorageListener implements Listener {
-    // todo: implement pagination
+
+    private static final int PAGE_SIZE = 45;
+    private static final int PREV_BUTTON = 45;
+    private static final int NEXT_BUTTON = 53;
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getView().getTopInventory().getHolder() instanceof WandStorage storage)) return;
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+
+        event.setCancelled(true);
+        int slot = event.getRawSlot();
+
+        switch (slot) {
+            case PREV_BUTTON -> storage.open(player, storage.getCurrentPage() - 1);
+            case NEXT_BUTTON -> storage.open(player, storage.getCurrentPage() + 1);
+            default -> {
+                if (slot >= 0 && slot < PAGE_SIZE) {
+                    handleItemWithdraw(storage, player, event, slot);
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        if (!(event.getView().getTopInventory().getHolder() instanceof WandStorage storage)) return;
+        int page = storage.getCurrentPage();
+        for (int i = 0; i < PAGE_SIZE; i++) {
+            ItemStack item = event.getView().getTopInventory().getItem(i);
+            storage.setItem(page * PAGE_SIZE + i, item);
+        }
+        persistStorage();
+    }
+
+    private void handleItemWithdraw(WandStorage storage, Player player, InventoryClickEvent event, int slot) {
+        ItemStack clicked = event.getView().getTopInventory().getItem(slot);
+        if (clicked == null || clicked.getType().isAir()) return;
+        int index = storage.getCurrentPage() * PAGE_SIZE + slot;
+        if (event.isShiftClick() || event.isLeftClick()) {
+            handleFullStackWithdraw(storage, player, clicked, index);
+        }
+        else if (event.isRightClick()) {
+            handleSingleWithdraw(storage, player, clicked, index);
+        }
+    }
+
+    private void handleFullStackWithdraw(WandStorage storage, Player player, ItemStack clicked, int index) {
+        ItemStack toGive = clicked.clone();
+        Map<Integer, ItemStack> leftover = player.getInventory().addItem(toGive);
+        if (leftover.isEmpty()) {
+            storage.removeItem(index);
+        }
+        else {
+            int given = toGive.getAmount() - leftover.values().stream().mapToInt(ItemStack::getAmount).sum();
+            if (given > 0) {
+                clicked.setAmount(clicked.getAmount() - given);
+                storage.setItem(index, clicked);
+            }
+        }
+    }
+
+    private void handleSingleWithdraw(WandStorage storage, Player player, ItemStack clicked, int index) {
+        ItemStack single = clicked.clone();
+        single.setAmount(1);
+        Map<Integer, ItemStack> leftover = player.getInventory().addItem(single);
+        if (leftover.isEmpty()) {
+            clicked.setAmount(clicked.getAmount() - 1);
+            storage.setItem(index, clicked.getAmount() > 0 ? clicked : null);
+        }
+    }
+
+    private void persistStorage() {
+        if (BuildersWand.getStorageManager() instanceof WandStorageManager manager) {
+            try {
+                manager.save();
+            }
+            catch (Exception e) {
+                ComponentUtil.error("Failed to save wand storage: " + e.getMessage());
+            }
+        }
+    }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
@@ -2,31 +2,37 @@ package dev.heypr.buildersWand.listeners;
 
 import dev.heypr.buildersWand.BuildersWand;
 import dev.heypr.buildersWand.managers.WandStorage;
-import dev.heypr.buildersWand.managers.WandStorageManager;
-import dev.heypr.buildersWand.utility.ComponentUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Map;
-
+// TODO CANCEL DRAG AND ITEM MOVE EVENTS
 public class WandStorageListener implements Listener {
 
     private static final int PAGE_SIZE = 45;
     private static final int PREV_BUTTON = 45;
+    private static final int PAGE_BUTTON = 49;
     private static final int NEXT_BUTTON = 53;
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
+        Inventory clickedInventory = event.getClickedInventory();
+        if (clickedInventory == null) return;
         if (!(event.getView().getTopInventory().getHolder() instanceof WandStorage storage)) return;
-        if (!(event.getWhoClicked() instanceof Player player)) return;
 
-        int slot = event.getRawSlot();
+        Player player = (Player) event.getWhoClicked();
 
-        switch (slot) {
+        int rawSlot = event.getRawSlot();
+
+        if (clickedInventory.equals(event.getView().getTopInventory()) && rawSlot >= PAGE_SIZE) {
+            event.setCancelled(true);
+        }
+
+        switch (rawSlot) {
             case PREV_BUTTON -> {
                 event.setCancelled(true);
                 storage.open(player, storage.getCurrentPage() - 1);
@@ -35,11 +41,7 @@ public class WandStorageListener implements Listener {
                 event.setCancelled(true);
                 storage.open(player, storage.getCurrentPage() + 1);
             }
-            default -> {
-                if (slot >= 0 && slot < PAGE_SIZE) {
-                    handleItemWithdraw(storage, player, event, slot);
-                }
-            }
+            case PAGE_BUTTON -> event.setCancelled(true);
         }
     }
 
@@ -51,54 +53,6 @@ public class WandStorageListener implements Listener {
             ItemStack item = event.getView().getTopInventory().getItem(i);
             storage.setItem(page * PAGE_SIZE + i, item);
         }
-        persistStorage();
-    }
-
-    private void handleItemWithdraw(WandStorage storage, Player player, InventoryClickEvent event, int slot) {
-        ItemStack clicked = event.getView().getTopInventory().getItem(slot);
-        if (clicked == null || clicked.getType().isAir()) return;
-        int index = storage.getCurrentPage() * PAGE_SIZE + slot;
-        if (event.isShiftClick() || event.isLeftClick()) {
-            handleFullStackWithdraw(storage, player, clicked, index);
-        }
-        else if (event.isRightClick()) {
-            handleSingleWithdraw(storage, player, clicked, index);
-        }
-    }
-
-    private void handleFullStackWithdraw(WandStorage storage, Player player, ItemStack clicked, int index) {
-        ItemStack toGive = clicked.clone();
-        Map<Integer, ItemStack> leftover = player.getInventory().addItem(toGive);
-        if (leftover.isEmpty()) {
-            storage.removeItem(index);
-        }
-        else {
-            int given = toGive.getAmount() - leftover.values().stream().mapToInt(ItemStack::getAmount).sum();
-            if (given > 0) {
-                clicked.setAmount(clicked.getAmount() - given);
-                storage.setItem(index, clicked);
-            }
-        }
-    }
-
-    private void handleSingleWithdraw(WandStorage storage, Player player, ItemStack clicked, int index) {
-        ItemStack single = clicked.clone();
-        single.setAmount(1);
-        Map<Integer, ItemStack> leftover = player.getInventory().addItem(single);
-        if (leftover.isEmpty()) {
-            clicked.setAmount(clicked.getAmount() - 1);
-            storage.setItem(index, clicked.getAmount() > 0 ? clicked : null);
-        }
-    }
-
-    private void persistStorage() {
-        if (BuildersWand.getStorageManager() instanceof WandStorageManager manager) {
-            try {
-                manager.save();
-            }
-            catch (Exception e) {
-                ComponentUtil.error("Failed to save wand storage: " + e.getMessage());
-            }
-        }
+        BuildersWand.getStorageManager().save(storage.getWand());
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
@@ -1,0 +1,8 @@
+package dev.heypr.buildersWand.listeners;
+
+import org.bukkit.event.Listener;
+
+public class WandStorageListener implements Listener {
+    // todo: implement pagination
+}
+

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandStorageListener.java
@@ -5,4 +5,3 @@ import org.bukkit.event.Listener;
 public class WandStorageListener implements Listener {
     // todo: implement pagination
 }
-

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
@@ -8,12 +8,12 @@ import dev.heypr.buildersWand.hooks.BentoBoxHook;
 import dev.heypr.buildersWand.hooks.LandsHook;
 import dev.heypr.buildersWand.hooks.SuperiorSkyblockHook;
 import dev.heypr.buildersWand.hooks.WorldGuardHook;
-import dev.heypr.buildersWand.utility.BlockFinderUtil;
 import dev.heypr.buildersWand.managers.PlacementQueueManager;
 import dev.heypr.buildersWand.managers.WandManager;
 import dev.heypr.buildersWand.managers.WandSession;
 import dev.heypr.buildersWand.managers.io.ConfigManager;
 import dev.heypr.buildersWand.managers.io.MessageManager;
+import dev.heypr.buildersWand.utility.BlockFinderUtil;
 import dev.heypr.buildersWand.utility.ComponentUtil;
 import dev.heypr.buildersWand.utility.InventoryUtil;
 import org.bukkit.*;
@@ -72,14 +72,7 @@ public class WandUseListener implements Listener {
         }
         Wand wand = WandManager.getWand(wandItem);
         if (wand == null) {
-            if (ConfigManager.shouldDestroyInvalidWands()) {
-                ComponentUtil.error("Removing misconfigured wand from their inventory...");
-                player.getInventory().removeItem(wandItem);
-                MessageManager.sendMessage(player, MessageManager.Messages.MISCONFIGURED);
-            }
-            else {
-                ComponentUtil.error("Misconfigured wand not removed due to configuration option.");
-            }
+            handleMisconfiguredWand(player, wandItem);
             return;
         }
         if (!event.getAction().isRightClick() || event.getHand() != EquipmentSlot.HAND) {
@@ -99,9 +92,24 @@ public class WandUseListener implements Listener {
             generatePreview(player, wand);
             return;
         }
+        handlePlacement(player, wand, session);
+    }
+
+    private void handleMisconfiguredWand(Player player, ItemStack wandItem) {
+        if (ConfigManager.shouldDestroyInvalidWands()) {
+            ComponentUtil.error("Removing misconfigured wand from their inventory...");
+            player.getInventory().removeItem(wandItem);
+            MessageManager.sendMessage(player, MessageManager.Messages.MISCONFIGURED);
+        }
+        else {
+            ComponentUtil.error("Misconfigured wand not removed due to configuration option.");
+        }
+    }
+
+    private void handlePlacement(Player player, Wand wand, WandSession session) {
         long now = System.currentTimeMillis();
         long last = session.lastRightClickTime;
-        float cooldown = wand.getCooldown() * 1000L;
+        long cooldown = (long) (wand.getCooldown() * 1000L);
         if (now - last < cooldown) {
             MessageManager.sendActionBar(player, MessageManager.Messages.COOLDOWN_ACTIVE, "seconds", String.valueOf((int) ((cooldown - (now - last)) / 1000)));
             return;
@@ -134,59 +142,74 @@ public class WandUseListener implements Listener {
         }
         Set<Block> finalBlocksToPlace = new HashSet<>(session.previewBlocks);
         if (ConfigManager.shouldFireBlockPlaceEvent()) {
-            WandPlaceEvent wandEvent = new WandPlaceEvent(player, wandItem, wand, session.previewBlocks);
+            WandPlaceEvent wandEvent = new WandPlaceEvent(player, player.getInventory().getItemInMainHand(), wand, session.previewBlocks);
             Bukkit.getPluginManager().callEvent(wandEvent);
             if (wandEvent.isCancelled()) return;
             finalBlocksToPlace = wandEvent.getBlocksToPlace();
         }
-        if (wand.getUndoHistorySize() != 0) {
-            List<BlockState> currentAction = new ArrayList<>();
-            for (Block block : finalBlocksToPlace) {
-                currentAction.add(block.getState());
-            }
-            session.undoHistory.push(currentAction);
-        }
-        if (session.undoHistory.size() > wand.getUndoHistorySize() && wand.getUndoHistorySize() != -1) {
-            session.undoHistory.removeFirst();
-        }
+        storeUndoHistory(wand, session, finalBlocksToPlace);
         if (!player.getGameMode().equals(GameMode.CREATIVE) && wand.consumesItems()) {
             InventoryUtil.removeItems(player, session.lastTargetBlock.getType(), needed);
         }
+        placeBlocks(player, session, finalBlocksToPlace);
+        handleDurability(player, wand, player.getInventory().getItemInMainHand());
+        if (!wand.generatePreviewOnMove()) {
+            session.initialPlace = true;
+        }
+    }
+
+    private void storeUndoHistory(Wand wand, WandSession session, Set<Block> blocks) {
+        if (wand.getUndoHistorySize() == 0) return;
+        List<BlockState> currentAction = new ArrayList<>();
+        for (Block block : blocks) {
+            currentAction.add(block.getState());
+        }
+        session.undoHistory.push(currentAction);
+        if (session.undoHistory.size() > wand.getUndoHistorySize() && wand.getUndoHistorySize() != -1) {
+            session.undoHistory.removeFirst();
+        }
+    }
+
+    private void placeBlocks(Player player, WandSession session, Set<Block> blocks) {
         if (ConfigManager.isPlacementQueueEnabled()) {
-            new PlacementQueueManager(player, finalBlocksToPlace, session.lastTargetBlock.getType(), ConfigManager.getMaxBlocksPerTick()).start();
+            new PlacementQueueManager(player, blocks, session.lastTargetBlock.getType(), ConfigManager.getMaxBlocksPerTick()).start();
         }
         else {
-            for (Block block : finalBlocksToPlace) {
+            for (Block block : blocks) {
                 block.setType(session.lastTargetBlock.getType(), true);
             }
         }
         session.previewBlocks.clear();
         session.lastTargetBlock = null;
         session.lastTargetFace = null;
-        if (WandManager.isWandDurabilityEnabled(wandItem)) {
-            if (WandManager.getWandDurability(wandItem) <= 1) {
-                player.getInventory().removeItem(wandItem);
-                if (wand.isBreakSoundEnabled()) {
-                    if (wand.getBreakSound() == null) {
-                        ComponentUtil.error("Break sound not configured for wand " + wand.getId() + ". Using default sound.");
-                        player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
-                    }
-                    else {
-                        player.playSound(player.getLocation(), wand.getBreakSound(), 1.0f, 1.0f);
-                    }
-                    player.sendActionBar(wand.getBreakSoundMessage());
-                }
-            }
-            else {
-                WandManager.decrementWandDurability(wandItem);
+    }
+
+    private void handleDurability(Player player, Wand wand, ItemStack wandItem) {
+        if (!WandManager.isWandDurabilityEnabled(wandItem)) {
+            WandManager.handleInfiniteDurability(wandItem);
+            return;
+        }
+        if (WandManager.getWandDurability(wandItem) <= 1) {
+            player.getInventory().removeItem(wandItem);
+            if (wand.isBreakSoundEnabled()) {
+                playBreakSound(player, wand);
             }
         }
         else {
-            WandManager.handleInfiniteDurability(wandItem);
+            WandManager.decrementWandDurability(wandItem);
         }
-        if (!wand.generatePreviewOnMove()) {
-            session.initialPlace = true;
+    }
+
+    private void playBreakSound(Player player, Wand wand) {
+        Sound sound = wand.getBreakSound();
+        if (sound == null) {
+            ComponentUtil.error("Break sound not configured for wand " + wand.getId() + ". Using default sound.");
+            player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
         }
+        else {
+            player.playSound(player.getLocation(), sound, 1.0f, 1.0f);
+        }
+        player.sendActionBar(wand.getBreakSoundMessage());
     }
 
     @EventHandler(ignoreCancelled = true)
@@ -202,7 +225,7 @@ public class WandUseListener implements Listener {
         if (!WandManager.isWand(itemInHand)) {
             return;
         }
-        else if (!WandManager.isRegisteredWand(itemInHand)) {
+        if (!WandManager.isRegisteredWand(itemInHand)) {
             if (ConfigManager.shouldDestroyInvalidWands()) {
                 ComponentUtil.error("Removing misconfigured wand from their inventory...");
                 player.getInventory().removeItem(itemInHand);
@@ -225,7 +248,6 @@ public class WandUseListener implements Listener {
             return;
         }
         List<BlockState> lastAction = session.undoHistory.pop();
-        // todo: item return. to be moved to inventoryutil.
         List<ItemStack> itemsToReturn = new ArrayList<>();
         for (BlockState oldState : lastAction) {
             Block currentBlock = oldState.getBlock();
@@ -234,10 +256,9 @@ public class WandUseListener implements Listener {
             }
             oldState.update(true, false);
         }
-        if (!itemsToReturn.isEmpty() && !player.getGameMode().isInvulnerable()) {
-            player.give(itemsToReturn.toArray(new ItemStack[0]));
+        if (!itemsToReturn.isEmpty()) {
+            InventoryUtil.returnItems(player, itemsToReturn);
         }
-        // todo: item return. to be moved to inventoryutil.
         MessageManager.sendActionBar(player, MessageManager.Messages.ACTION_UNDONE, "remaining", session.undoHistory.size());
     }
 
@@ -336,29 +357,41 @@ public class WandUseListener implements Listener {
                     return;
                 }
                 World world = player.getWorld();
-                Particle particle;
-                try {
-                    particle = Particle.valueOf(wand.getPreviewParticle());
-                }
-                catch (Exception e) {
-                    particle = Particle.DUST;
-                }
-                Particle.DustOptions dustOptions = particle == Particle.DUST ? new Particle.DustOptions(Color.fromRGB(wand.getPreviewParticleOptionsRed(), wand.getPreviewParticleOptionsGreen(), wand.getPreviewParticleOptionsBlue()), (float) wand.getPreviewParticleOptionsSize()) : null;
+                Particle particle = tryParseParticle(wand.getPreviewParticle());
+                Particle.DustOptions dustOptions = particle == Particle.DUST ?
+                    new Particle.DustOptions(
+                        Color.fromRGB(wand.getPreviewParticleOptionsRed(), wand.getPreviewParticleOptionsGreen(), wand.getPreviewParticleOptionsBlue()),
+                        (float) wand.getPreviewParticleOptionsSize()
+                    ) : null;
+
                 for (Block preview : session.previewBlocks) {
                     if (!preview.getWorld().equals(world)) {
                         continue;
                     }
                     Location loc = preview.getLocation().add(0.5, 0.5, 0.5);
                     if (dustOptions != null) {
-                        world.spawnParticle(Particle.DUST, loc, wand.getPreviewParticleCount(), wand.getPreviewParticleOffsetX(), wand.getPreviewParticleOffsetY(), wand.getPreviewParticleOffsetZ(), wand.getPreviewParticleSpeed(), dustOptions);
+                        world.spawnParticle(Particle.DUST, loc, wand.getPreviewParticleCount(),
+                            wand.getPreviewParticleOffsetX(), wand.getPreviewParticleOffsetY(), wand.getPreviewParticleOffsetZ(),
+                            wand.getPreviewParticleSpeed(), dustOptions);
                     }
                     else {
-                        world.spawnParticle(particle, loc, wand.getPreviewParticleCount(), wand.getPreviewParticleOffsetX(), wand.getPreviewParticleOffsetY(), wand.getPreviewParticleOffsetZ(), wand.getPreviewParticleSpeed());
+                        world.spawnParticle(particle, loc, wand.getPreviewParticleCount(),
+                            wand.getPreviewParticleOffsetX(), wand.getPreviewParticleOffsetY(), wand.getPreviewParticleOffsetZ(),
+                            wand.getPreviewParticleSpeed());
                     }
                 }
             }
         };
         session.particleTask.runTaskTimer(BuildersWand.getInstance(), 0L, 5L);
+    }
+
+    private Particle tryParseParticle(String particleName) {
+        try {
+            return Particle.valueOf(particleName);
+        }
+        catch (Exception e) {
+            return Particle.DUST;
+        }
     }
 
     public void unlockPlayer(Player player) {

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
@@ -8,13 +8,14 @@ import dev.heypr.buildersWand.hooks.BentoBoxHook;
 import dev.heypr.buildersWand.hooks.LandsHook;
 import dev.heypr.buildersWand.hooks.SuperiorSkyblockHook;
 import dev.heypr.buildersWand.hooks.WorldGuardHook;
-import dev.heypr.buildersWand.managers.BlockFinder;
+import dev.heypr.buildersWand.utility.BlockFinderUtil;
 import dev.heypr.buildersWand.managers.PlacementQueueManager;
 import dev.heypr.buildersWand.managers.WandManager;
 import dev.heypr.buildersWand.managers.WandSession;
 import dev.heypr.buildersWand.managers.io.ConfigManager;
 import dev.heypr.buildersWand.managers.io.MessageManager;
-import dev.heypr.buildersWand.utility.Util;
+import dev.heypr.buildersWand.utility.ComponentUtil;
+import dev.heypr.buildersWand.utility.InventoryUtil;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -23,10 +24,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.block.CrafterCraftEvent;
-import org.bukkit.event.inventory.FurnaceBurnEvent;
-import org.bukkit.event.inventory.FurnaceSmeltEvent;
-import org.bukkit.event.inventory.PrepareItemCraftEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.inventory.EquipmentSlot;
@@ -37,56 +34,20 @@ import org.bukkit.util.RayTraceResult;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
-public class WandListener implements Listener {
-    private static WandListener instance;
+public class WandUseListener implements Listener {
+    private static WandUseListener instance;
     private final Map<UUID, WandSession> sessions = new HashMap<>();
 
-    public WandListener() {
+    public WandUseListener() {
         instance = this;
     }
 
-    public static WandListener getInstance() {
+    public static WandUseListener getInstance() {
         return instance;
     }
 
     private WandSession getSession(Player player) {
         return sessions.computeIfAbsent(player.getUniqueId(), k -> new WandSession());
-    }
-
-    @EventHandler
-    public void onCraft(PrepareItemCraftEvent event) {
-        for (ItemStack item : event.getInventory().getMatrix()) {
-            if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
-                event.getInventory().setResult(null);
-                break;
-            }
-        }
-    }
-
-    @EventHandler
-    public void onCrafterCraft(CrafterCraftEvent event) {
-        ItemStack item = event.getResult();
-        if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
-            event.setResult(new ItemStack(Material.AIR));
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler
-    public void onFurnaceBurn(FurnaceBurnEvent event) {
-        ItemStack item = event.getFuel();
-        if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
-            event.setConsumeFuel(false);
-            event.setCancelled(true);
-        }
-    }
-
-    @EventHandler
-    public void onFurnaceSmelt(FurnaceSmeltEvent event) {
-        ItemStack item = event.getResult();
-        if (WandManager.isWand(item) && !WandManager.getWand(item).isCraftable()) {
-            event.setCancelled(true);
-        }
     }
 
     @EventHandler
@@ -112,12 +73,12 @@ public class WandListener implements Listener {
         Wand wand = WandManager.getWand(wandItem);
         if (wand == null) {
             if (ConfigManager.shouldDestroyInvalidWands()) {
-                Util.error("Removing misconfigured wand from their inventory...");
+                ComponentUtil.error("Removing misconfigured wand from their inventory...");
                 player.getInventory().removeItem(wandItem);
                 MessageManager.sendMessage(player, MessageManager.Messages.MISCONFIGURED);
             }
             else {
-                Util.error("Misconfigured wand not removed due to configuration option.");
+                ComponentUtil.error("Misconfigured wand not removed due to configuration option.");
             }
             return;
         }
@@ -147,7 +108,7 @@ public class WandListener implements Listener {
         }
         int needed = session.previewBlocks.size();
         if (!player.getGameMode().equals(GameMode.CREATIVE) && wand.consumesItems()) {
-            int available = getItemCount(player, session.lastTargetBlock.getType());
+            int available = InventoryUtil.getItemCount(player, session.lastTargetBlock.getType());
             if (available < needed) {
                 MessageManager.sendMessage(player, MessageManager.Messages.INSUFFICIENT_BLOCKS, "needed", needed - available, "material", session.lastTargetBlock.getType().name());
                 session.previewBlocks.clear();
@@ -189,7 +150,7 @@ public class WandListener implements Listener {
             session.undoHistory.removeFirst();
         }
         if (!player.getGameMode().equals(GameMode.CREATIVE) && wand.consumesItems()) {
-            removeItems(player, session.lastTargetBlock.getType(), needed);
+            InventoryUtil.removeItems(player, session.lastTargetBlock.getType(), needed);
         }
         if (ConfigManager.isPlacementQueueEnabled()) {
             new PlacementQueueManager(player, finalBlocksToPlace, session.lastTargetBlock.getType(), ConfigManager.getMaxBlocksPerTick()).start();
@@ -207,7 +168,7 @@ public class WandListener implements Listener {
                 player.getInventory().removeItem(wandItem);
                 if (wand.isBreakSoundEnabled()) {
                     if (wand.getBreakSound() == null) {
-                        Util.error("Break sound not configured for wand " + wand.getId() + ". Using default sound.");
+                        ComponentUtil.error("Break sound not configured for wand " + wand.getId() + ". Using default sound.");
                         player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
                     }
                     else {
@@ -243,12 +204,12 @@ public class WandListener implements Listener {
         }
         else if (!WandManager.isRegisteredWand(itemInHand)) {
             if (ConfigManager.shouldDestroyInvalidWands()) {
-                Util.error("Removing misconfigured wand from their inventory...");
+                ComponentUtil.error("Removing misconfigured wand from their inventory...");
                 player.getInventory().removeItem(itemInHand);
                 MessageManager.sendMessage(player, MessageManager.Messages.MISCONFIGURED);
             }
             else {
-                Util.error("Misconfigured wand not removed due to configuration option.");
+                ComponentUtil.error("Misconfigured wand not removed due to configuration option.");
             }
         }
         Wand wand = WandManager.getWand(itemInHand);
@@ -264,6 +225,7 @@ public class WandListener implements Listener {
             return;
         }
         List<BlockState> lastAction = session.undoHistory.pop();
+        // todo: item return. to be moved to inventoryutil.
         List<ItemStack> itemsToReturn = new ArrayList<>();
         for (BlockState oldState : lastAction) {
             Block currentBlock = oldState.getBlock();
@@ -275,6 +237,7 @@ public class WandListener implements Listener {
         if (!itemsToReturn.isEmpty() && !player.getGameMode().isInvulnerable()) {
             player.give(itemsToReturn.toArray(new ItemStack[0]));
         }
+        // todo: item return. to be moved to inventoryutil.
         MessageManager.sendActionBar(player, MessageManager.Messages.ACTION_UNDONE, "remaining", session.undoHistory.size());
     }
 
@@ -302,10 +265,10 @@ public class WandListener implements Listener {
         session.lastTargetFace = face;
         session.currentCalculation = CompletableFuture.supplyAsync(() -> {
             if (wand.getWandType() == Wand.WandType.STATIC) {
-                return BlockFinder.getStaticBlocks(hitBlock, face, wand.getStaticLength(), wand.getStaticWidth());
+                return BlockFinderUtil.getStaticBlocks(hitBlock, face, wand.getStaticLength(), wand.getStaticWidth());
             }
             else {
-                return BlockFinder.findConnectedBlocks(hitBlock, face, wand.getMaxSize(), wand.getBlockedMaterials());
+                return BlockFinderUtil.findConnectedBlocks(hitBlock, face, wand.getMaxSize(), wand.getBlockedMaterials());
             }
         }).thenAcceptAsync(sourceBlocks -> {
             Set<Block> validTargets = new HashSet<>();
@@ -350,7 +313,7 @@ public class WandListener implements Listener {
                 return false;
             }
         }
-        return BlockFinder.isReplaceable(target);
+        return BlockFinderUtil.isReplaceable(target);
     }
 
     private void startParticleTask(Player player, Wand wand, WandSession session) {
@@ -400,33 +363,5 @@ public class WandListener implements Listener {
 
     public void unlockPlayer(Player player) {
         getSession(player).placing = false;
-    }
-
-    private int getItemCount(Player player, Material material) {
-        int count = 0;
-        for (ItemStack item : player.getInventory().getContents()) {
-            if (item != null && item.getType() == material) {
-                count += item.getAmount();
-            }
-        }
-        return count;
-    }
-
-    private void removeItems(Player player, Material material, int amount) {
-        int remaining = amount;
-        for (ItemStack item : player.getInventory().getContents()) {
-            if (item == null || item.getType() != material) {
-                continue;
-            }
-            int amt = item.getAmount();
-            if (amt <= remaining) {
-                remaining -= amt;
-                item.setAmount(0);
-            }
-            else {
-                item.setAmount(amt - remaining);
-                break;
-            }
-        }
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
@@ -11,6 +11,7 @@ import dev.heypr.buildersWand.hooks.WorldGuardHook;
 import dev.heypr.buildersWand.managers.PlacementQueueManager;
 import dev.heypr.buildersWand.managers.WandManager;
 import dev.heypr.buildersWand.managers.WandSession;
+import dev.heypr.buildersWand.managers.WandStorage;
 import dev.heypr.buildersWand.managers.io.ConfigManager;
 import dev.heypr.buildersWand.managers.io.MessageManager;
 import dev.heypr.buildersWand.utility.BlockFinderUtil;
@@ -26,6 +27,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -61,6 +63,22 @@ public class WandUseListener implements Listener {
         if (wand != null && wand.generatePreviewOnMove()) {
             generatePreview(player, wand);
         }
+    }
+
+    @EventHandler
+    public void onPlayerSwap(PlayerSwapHandItemsEvent event) {
+        Player player = event.getPlayer();
+        ItemStack wandItem = player.getInventory().getItemInMainHand();
+        if (!WandManager.isWand(wandItem)) {
+            return;
+        }
+        if (!ConfigManager.isWandStorageEnabled()) {
+            return;
+        }
+        event.setCancelled(true);
+        Wand wand = WandManager.getWand(wandItem);
+        WandStorage storage = BuildersWand.getStorageManager().getStorage(wand);
+        player.openInventory(storage.getInventory());
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
@@ -69,16 +69,16 @@ public class WandUseListener implements Listener {
     public void onPlayerSwap(PlayerSwapHandItemsEvent event) {
         Player player = event.getPlayer();
         ItemStack wandItem = player.getInventory().getItemInMainHand();
-        if (!WandManager.isWand(wandItem)) {
-            return;
-        }
         if (!ConfigManager.isWandStorageEnabled()) {
             return;
         }
         event.setCancelled(true);
         Wand wand = WandManager.getWand(wandItem);
+        if (wand == null) {
+            return;
+        }
         WandStorage storage = BuildersWand.getStorageManager().getStorage(wand);
-        player.openInventory(storage.getInventory());
+        storage.open(player, 0);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/listeners/WandUseListener.java
@@ -134,7 +134,7 @@ public class WandUseListener implements Listener {
         }
         int needed = session.previewBlocks.size();
         if (!player.getGameMode().equals(GameMode.CREATIVE) && wand.consumesItems()) {
-            int available = InventoryUtil.getItemCount(player, session.lastTargetBlock.getType());
+            int available = InventoryUtil.getItemCount(player, session.lastTargetBlock.getType(), wand);
             if (available < needed) {
                 MessageManager.sendMessage(player, MessageManager.Messages.INSUFFICIENT_BLOCKS, "needed", needed - available, "material", session.lastTargetBlock.getType().name());
                 session.previewBlocks.clear();
@@ -167,7 +167,7 @@ public class WandUseListener implements Listener {
         }
         storeUndoHistory(wand, session, finalBlocksToPlace);
         if (!player.getGameMode().equals(GameMode.CREATIVE) && wand.consumesItems()) {
-            InventoryUtil.removeItems(player, session.lastTargetBlock.getType(), needed);
+            InventoryUtil.removeItems(player, session.lastTargetBlock.getType(), needed, wand);
         }
         placeBlocks(player, session, finalBlocksToPlace);
         handleDurability(player, wand, player.getInventory().getItemInMainHand());
@@ -275,7 +275,7 @@ public class WandUseListener implements Listener {
             oldState.update(true, false);
         }
         if (!itemsToReturn.isEmpty()) {
-            InventoryUtil.returnItems(player, itemsToReturn);
+            InventoryUtil.returnItems(player, itemsToReturn, wand);
         }
         MessageManager.sendActionBar(player, MessageManager.Messages.ACTION_UNDONE, "remaining", session.undoHistory.size());
     }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/PlacementQueueManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/PlacementQueueManager.java
@@ -1,8 +1,9 @@
 package dev.heypr.buildersWand.managers;
 
 import dev.heypr.buildersWand.BuildersWand;
-import dev.heypr.buildersWand.listeners.WandListener;
+import dev.heypr.buildersWand.listeners.WandUseListener;
 import dev.heypr.buildersWand.managers.io.MessageManager;
+import dev.heypr.buildersWand.utility.BlockFinderUtil;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -43,7 +44,7 @@ public class PlacementQueueManager {
                     if (size > 50) {
                         MessageManager.sendMessage(player, MessageManager.Messages.PLACEMENT_COMPLETE);
                     }
-                    WandListener.getInstance().unlockPlayer(player);
+                    WandUseListener.getInstance().unlockPlayer(player);
                     this.cancel();
                 }
             }
@@ -55,6 +56,6 @@ public class PlacementQueueManager {
     }
 
     private boolean isReplaceable(Material material) {
-        return BlockFinder.REPLACEABLE.contains(material);
+        return BlockFinderUtil.REPLACEABLE.contains(material);
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/RecipeManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/RecipeManager.java
@@ -2,7 +2,7 @@ package dev.heypr.buildersWand.managers;
 
 import dev.heypr.buildersWand.BuildersWand;
 import dev.heypr.buildersWand.api.Wand;
-import dev.heypr.buildersWand.utility.Util;
+import dev.heypr.buildersWand.utility.ComponentUtil;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -28,12 +28,12 @@ public class RecipeManager {
                 recipe.shape(wand.getRecipeShape().toArray(new String[0]));
                 for (Map.Entry<Character, Material> entry : wand.getRecipeIngredients().entrySet()) {
                     recipe.setIngredient(entry.getKey(), entry.getValue());
-                    Util.debug("Set ingredient '" + entry.getKey() + "' to " + entry.getValue());
-                    Util.debug("Current recipe shape: " + String.join(", ", wand.getRecipeShape()));
+                    ComponentUtil.debug("Set ingredient '" + entry.getKey() + "' to " + entry.getValue());
+                    ComponentUtil.debug("Current recipe shape: " + String.join(", ", wand.getRecipeShape()));
                 }
-                Util.debug("Registering crafting recipe for wand ID: " + wand.getId());
+                ComponentUtil.debug("Registering crafting recipe for wand ID: " + wand.getId());
                 plugin.getServer().addRecipe(recipe, true);
-                Util.debug("Successfully registered crafting recipe for wand ID: " + wand.getId());
+                ComponentUtil.debug("Successfully registered crafting recipe for wand ID: " + wand.getId());
             }
         }
     }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandManager.java
@@ -2,7 +2,7 @@ package dev.heypr.buildersWand.managers;
 
 import dev.heypr.buildersWand.BuildersWand;
 import dev.heypr.buildersWand.api.Wand;
-import dev.heypr.buildersWand.utility.Util;
+import dev.heypr.buildersWand.utility.ComponentUtil;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.TextReplacementConfig;
@@ -20,13 +20,13 @@ public class WandManager {
     private final Map<String, Wand> wandConfigMap = new HashMap<>();
 
     public void registerWands() {
-        Util.debug("Starting wand registration process...");
+        ComponentUtil.debug("Starting wand registration process...");
         wandConfigMap.clear();
         List<Wand> loaded = loadWandConfigs();
-        Util.debug("Loaded " + loaded.size() + " wand configurations from config.");
+        ComponentUtil.debug("Loaded " + loaded.size() + " wand configurations from config.");
         loaded.forEach(wand -> {
             wandConfigMap.put(wand.getId(), wand);
-            Util.debug("Successfully registered wand ID: " + wand.getId() + " (" + wand.getName() + ")");
+            ComponentUtil.debug("Successfully registered wand ID: " + wand.getId() + " (" + wand.getName() + ")");
         });
     }
 
@@ -35,10 +35,10 @@ public class WandManager {
     }
 
     public static Wand getWandConfig(String wandId) {
-        Util.debug("Fetching wand config for ID: " + wandId);
+        ComponentUtil.debug("Fetching wand config for ID: " + wandId);
         Wand wand = BuildersWand.getWandManager().wandConfigMap.get(wandId);
         if (wand == null) {
-            Util.debug("Warning: No registered wand found for ID: " + wandId);
+            ComponentUtil.debug("Warning: No registered wand found for ID: " + wandId);
         }
         return wand;
     }
@@ -51,7 +51,7 @@ public class WandManager {
             return false;
         }
         boolean hasKey = item.getItemMeta().getPersistentDataContainer().has(BuildersWand.PDC_KEY_ID, PersistentDataType.STRING);
-        Util.debug("Checking isWand: " + (hasKey ? "YES" : "NO") + " for item " + item.getType());
+        ComponentUtil.debug("Checking isWand: " + (hasKey ? "YES" : "NO") + " for item " + item.getType());
         return hasKey;
     }
 
@@ -65,22 +65,22 @@ public class WandManager {
 
     public static Wand getWand(ItemStack item) {
         if (!isWand(item)) {
-            Util.debug("getWand failed: Item is not a wand.");
+            ComponentUtil.debug("getWand failed: Item is not a wand.");
             return null;
         }
         ItemMeta meta = item.getItemMeta();
         String wandId = meta.getPersistentDataContainer().get(BuildersWand.PDC_KEY_ID, PersistentDataType.STRING);
         if (wandId == null) {
-            Util.debug("getWand failed: PDC_KEY_ID is missing from item.");
+            ComponentUtil.debug("getWand failed: PDC_KEY_ID is missing from item.");
             return null;
         }
-        Util.debug("getWand found ID: " + wandId);
+        ComponentUtil.debug("getWand found ID: " + wandId);
         return getWandConfig(wandId);
     }
 
     public static String getWandID(ItemStack item) {
         if (!isWand(item)) {
-            Util.debug("getWandID failed: Item is not a wand.");
+            ComponentUtil.debug("getWandID failed: Item is not a wand.");
             return null;
         }
         ItemMeta meta = item.getItemMeta();
@@ -89,10 +89,10 @@ public class WandManager {
 
     public static ItemStack createWandItem(Wand item) {
         if (item == null) {
-            Util.debug("createWandItem failed: Wand object is null.");
+            ComponentUtil.debug("createWandItem failed: Wand object is null.");
             return null;
         }
-        Util.debug("Creating ItemStack for wand: " + item.getId());
+        ComponentUtil.debug("Creating ItemStack for wand: " + item.getId());
         ItemStack wandItem = new ItemStack(item.getMaterial());
         ItemMeta meta = wandItem.getItemMeta();
         if (meta != null) {
@@ -111,7 +111,7 @@ public class WandManager {
             meta.getPersistentDataContainer().set(BuildersWand.PDC_KEY_UUID, PersistentDataType.STRING, UUID.randomUUID().toString());
             meta.getPersistentDataContainer().set(BuildersWand.PDC_KEY_MAX_SIZE, PersistentDataType.INTEGER, item.getMaxSize());
             wandItem.setItemMeta(meta);
-            Util.debug("Wand ItemStack creation complete.");
+            ComponentUtil.debug("Wand ItemStack creation complete.");
         }
         return wandItem;
     }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
@@ -1,84 +1,146 @@
 package dev.heypr.buildersWand.managers;
 
-import dev.heypr.buildersWand.BuildersWand;
 import dev.heypr.buildersWand.api.Wand;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WandStorage implements InventoryHolder {
 
-    private final Inventory inventory;
+    private static final int PAGE_SIZE = 45;
+    private static final int INVENTORY_SIZE = 54;
+
     private final Wand wand;
     private final ConcurrentHashMap<Integer, ItemStack> contentMap = new ConcurrentHashMap<>();
-    private final Collection<ItemStack> contentList = this.contentMap.values();
+    private int currentPage = 0;
+    private Inventory inventory;
 
-    public WandStorage(BuildersWand plugin, Wand wand) {
-        this.inventory = plugin.getServer().createInventory(this, 54);
+    public WandStorage(Wand wand) {
         this.wand = wand;
+        this.inventory = buildInventoryForPage(0);
     }
 
     @Override
     @NotNull
     public Inventory getInventory() {
-        return this.inventory;
+        return inventory;
     }
 
     public Wand getWand() {
-        return this.wand;
+        return wand;
     }
 
-    public ItemStack getItem(int slot) {
-        return this.contentMap.get(slot);
+    public ItemStack getItem(int index) {
+        return contentMap.get(index);
     }
 
     public Collection<ItemStack> getItems() {
-        return this.contentList;
+        return contentMap.values();
     }
 
-    public void setItem(int slot, ItemStack item) {
-        this.contentMap.put(slot, item);
+    public Map<Integer, ItemStack> getAllContent() {
+        return Collections.unmodifiableMap(contentMap);
     }
 
-    public void removeItem(int slot) {
-        ItemStack item = this.contentMap.remove(slot);
-        if (item != null) {
-            this.contentList.remove(item);
+    public void setItem(int index, ItemStack item) {
+        if (item == null) {
+            contentMap.remove(index);
         }
+        else {
+            contentMap.put(index, item);
+        }
+        updateInventorySlot(index, item);
     }
 
-    public void removeItem(ItemStack item) {
-        this.contentMap.forEach((slot, itemStack) -> {
-            if (item.equals(itemStack)) {
-                this.contentMap.remove(slot);
-                this.contentList.remove(item);
-            }
-        });
-    }
-
-    public boolean hasExactItem(ItemStack item) {
-        return this.contentList.contains(item);
+    public void removeItem(int index) {
+        contentMap.remove(index);
+        updateInventorySlot(index, null);
     }
 
     public boolean hasItem(ItemStack item) {
-        return this.contentList.contains(item);
+        return contentMap.containsValue(item);
     }
 
     public boolean hasMaterial(Material material) {
-        for (ItemStack item : this.contentList) {
-            if (item.getType() == material) {
-                return true;
-            }
-        }
-        return false;
+        return contentMap.values().parallelStream().anyMatch(item -> item != null && item.getType() == material);
     }
 
     public int itemCount() {
-        return this.contentList.size();
+        return contentMap.values().parallelStream().mapToInt(item -> item != null ? item.getAmount() : 0).sum();
+    }
+
+    public int getTotalPages() {
+        return contentMap.keySet().stream()
+                .max(Integer::compareTo)
+                .map(maxIndex -> (maxIndex + PAGE_SIZE) / PAGE_SIZE)
+                .orElse(1);
+    }
+
+    public void open(Player player, int page) {
+        int totalPages = getTotalPages();
+        currentPage = Math.clamp(page, 0, totalPages - 1);
+        inventory = buildInventoryForPage(currentPage);
+        player.openInventory(inventory);
+    }
+
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    public int removeItems(Material material, int amount) {
+        int removed = 0;
+        List<Integer> toDelete = new ArrayList<>();
+        for (var entry : contentMap.entrySet()) {
+            if (removed >= amount) break;
+            if (entry.getValue() instanceof ItemStack stack && stack.getType() == material) {
+                int take = Math.min(stack.getAmount(), amount - removed);
+                stack.setAmount(stack.getAmount() - take);
+                removed += take;
+                if (stack.getAmount() <= 0) {
+                    toDelete.add(entry.getKey());
+                }
+            }
+        }
+        toDelete.forEach(contentMap::remove);
+        return removed;
+    }
+
+    private void updateInventorySlot(int index, ItemStack item) {
+        if (isIndexVisible(index)) {
+            inventory.setItem(index % PAGE_SIZE, item);
+        }
+    }
+
+    private boolean isIndexVisible(int index) {
+        return (index / PAGE_SIZE) == currentPage;
+    }
+
+    private Inventory buildInventoryForPage(int page) {
+        Inventory inv = Bukkit.createInventory(this, INVENTORY_SIZE, String.format("Wand Storage - %s (%d)", wand.getId(), page + 1));
+        int startIndex = page * PAGE_SIZE;
+        for (int i = 0; i < PAGE_SIZE; i++) {
+            inv.setItem(i, contentMap.get(startIndex + i));
+        }
+        inv.setItem(45, createControl(Material.ARROW, "Previous Page"));
+        inv.setItem(49, createControl(Material.PAPER, String.format("Page: %d", page + 1)));
+        inv.setItem(53, createControl(Material.ARROW, "Next Page"));
+        return inv;
+    }
+
+    private ItemStack createControl(Material material, String name) {
+        ItemStack item = new ItemStack(material);
+        if (item.getItemMeta() instanceof ItemMeta meta) {
+            meta.setDisplayName(name);
+            item.setItemMeta(meta);
+        }
+        return item;
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
@@ -1,0 +1,84 @@
+package dev.heypr.buildersWand.managers;
+
+import dev.heypr.buildersWand.BuildersWand;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class WandStorage implements InventoryHolder {
+
+    private final Inventory inventory;
+    private final Player player;
+    private final ConcurrentHashMap<Integer, ItemStack> contentMap = new ConcurrentHashMap<>();
+    private final Collection<ItemStack> contentList = this.contentMap.values();
+
+    public WandStorage(BuildersWand plugin, Player player) {
+        this.inventory = plugin.getServer().createInventory(this, 54);
+        this.player = player;
+    }
+
+    @Override
+    @NotNull
+    public Inventory getInventory() {
+        return this.inventory;
+    }
+
+    public Player getPlayer() {
+        return this.player;
+    }
+
+    public ItemStack getItem(int slot) {
+        return this.contentMap.get(slot);
+    }
+
+    public Collection<ItemStack> getItems() {
+        return this.contentList;
+    }
+
+    public void setItem(int slot, ItemStack item) {
+        this.contentMap.put(slot, item);
+    }
+
+    public void removeItem(int slot) {
+        ItemStack item = this.contentMap.remove(slot);
+        if (item != null) {
+            this.contentList.remove(item);
+        }
+    }
+
+    public void removeItem(ItemStack item) {
+        this.contentMap.forEach((slot, itemStack) -> {
+            if (item.equals(itemStack)) {
+                this.contentMap.remove(slot);
+                this.contentList.remove(item);
+            }
+        });
+    }
+
+    public boolean hasExactItem(ItemStack item) {
+        return this.contentList.contains(item);
+    }
+
+    public boolean hasItem(ItemStack item) {
+        return this.contentList.contains(item);
+    }
+
+    public boolean hasMaterial(Material material) {
+        for (ItemStack item : this.contentList) {
+            if (item.getType() == material) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int itemCount() {
+        return this.contentList.size();
+    }
+}

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
@@ -1,8 +1,8 @@
 package dev.heypr.buildersWand.managers;
 
 import dev.heypr.buildersWand.BuildersWand;
+import dev.heypr.buildersWand.api.Wand;
 import org.bukkit.Material;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
@@ -14,13 +14,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class WandStorage implements InventoryHolder {
 
     private final Inventory inventory;
-    private final Player player;
+    private final Wand wand;
     private final ConcurrentHashMap<Integer, ItemStack> contentMap = new ConcurrentHashMap<>();
     private final Collection<ItemStack> contentList = this.contentMap.values();
 
-    public WandStorage(BuildersWand plugin, Player player) {
+    public WandStorage(BuildersWand plugin, Wand wand) {
         this.inventory = plugin.getServer().createInventory(this, 54);
-        this.player = player;
+        this.wand = wand;
     }
 
     @Override
@@ -29,8 +29,8 @@ public class WandStorage implements InventoryHolder {
         return this.inventory;
     }
 
-    public Player getPlayer() {
-        return this.player;
+    public Wand getWand() {
+        return this.wand;
     }
 
     public ItemStack getItem(int slot) {

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
+// TODO FIX PAGINATION
 public class WandStorage implements InventoryHolder {
 
     private static final int PAGE_SIZE = 45;
@@ -55,8 +56,7 @@ public class WandStorage implements InventoryHolder {
     public void setItem(int index, ItemStack item) {
         if (item == null) {
             contentMap.remove(index);
-        }
-        else {
+        } else {
             contentMap.put(index, item);
         }
         updateInventorySlot(index, item);
@@ -99,19 +99,18 @@ public class WandStorage implements InventoryHolder {
 
     public int removeItems(Material material, int amount) {
         int removed = 0;
-        List<Integer> toDelete = new ArrayList<>();
         for (var entry : contentMap.entrySet()) {
             if (removed >= amount) break;
-            if (entry.getValue() instanceof ItemStack stack && stack.getType() == material) {
+            ItemStack stack = entry.getValue();
+            if (stack.getType().equals(material)) {
                 int take = Math.min(stack.getAmount(), amount - removed);
                 stack.setAmount(stack.getAmount() - take);
                 removed += take;
                 if (stack.getAmount() <= 0) {
-                    toDelete.add(entry.getKey());
+                    contentMap.remove(entry.getKey());
                 }
             }
         }
-        toDelete.forEach(contentMap::remove);
         return removed;
     }
 

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorage.java
@@ -1,6 +1,8 @@
 package dev.heypr.buildersWand.managers;
 
 import dev.heypr.buildersWand.api.Wand;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -124,7 +126,7 @@ public class WandStorage implements InventoryHolder {
     }
 
     private Inventory buildInventoryForPage(int page) {
-        Inventory inv = Bukkit.createInventory(this, INVENTORY_SIZE, String.format("Wand Storage - %s (%d)", wand.getId(), page + 1));
+        Inventory inv = Bukkit.createInventory(this, INVENTORY_SIZE, String.format("Wand Storage - %s (%d)", wand.getRawName(), page + 1));
         int startIndex = page * PAGE_SIZE;
         for (int i = 0; i < PAGE_SIZE; i++) {
             inv.setItem(i, contentMap.get(startIndex + i));
@@ -138,7 +140,7 @@ public class WandStorage implements InventoryHolder {
     private ItemStack createControl(Material material, String name) {
         ItemStack item = new ItemStack(material);
         if (item.getItemMeta() instanceof ItemMeta meta) {
-            meta.setDisplayName(name);
+            meta.customName(Component.text(name).decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE));
             item.setItemMeta(meta);
         }
         return item;

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
@@ -4,8 +4,6 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import dev.heypr.buildersWand.BuildersWand;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.PlayerJoinEvent;
 
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,12 +34,6 @@ public class WandStorageManager {
         config.addDataSourceProperty("synchronous", "NORMAL");
 
         this.dataSource = new HikariDataSource(config);
-    }
-
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        Player player = event.getPlayer();
-        WandStorage wandStorage = new WandStorage(plugin, player);
     }
 
     public void createTables() {

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
@@ -1,0 +1,68 @@
+package dev.heypr.buildersWand.managers;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import dev.heypr.buildersWand.BuildersWand;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import java.io.File;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class WandStorageManager {
+
+    private BuildersWand plugin;
+    private ConcurrentHashMap<Player, WandStorage> storage = new ConcurrentHashMap<>();
+    private final HikariDataSource dataSource;
+
+    public WandStorageManager(BuildersWand plugin) {
+        this.plugin = plugin;
+        File dataFolder = BuildersWand.getInstance().getDataFolder();
+        if (!dataFolder.exists()) {
+            dataFolder.mkdirs();
+        }
+
+        File dbFile = new File(dataFolder, "data.db");
+
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl("jdbc:sqlite:" + dbFile.getAbsolutePath());
+        config.setDriverClassName("org.sqlite.JDBC");
+        config.setPoolName("WandStoragePool");
+        config.setMaximumPoolSize(1);
+        config.setConnectionTestQuery("SELECT 1");
+
+        config.addDataSourceProperty("journal_mode", "WAL");
+        config.addDataSourceProperty("synchronous", "NORMAL");
+
+        this.dataSource = new HikariDataSource(config);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        WandStorage wandStorage = new WandStorage(plugin, player);
+    }
+
+    public void createTables() {
+        // create tables for sql storage if it doesn't exist.
+    }
+
+    public void load() {
+        // implement sql storage, loading from db to storage map in memory
+    }
+
+    public synchronized WandStorage getStorage(Player player) {
+        return storage.get(player);
+    }
+
+    public void save() {
+        // implement sql storage, saving storage map in memory to db
+    }
+
+    public void close() {
+        if (dataSource != null && !dataSource.isClosed()) {
+            dataSource.close();
+        }
+    }
+}

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
@@ -15,7 +15,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -90,19 +89,25 @@ public class WandStorageManager {
     }
 
     public void startAutosave() {
-        if (!ConfigManager.isWandStorageAutosaveEnabled()) return;
+        if (!ConfigManager.isWandStorageAutosaveEnabled()) {
+            return;
+        }
         long interval = ConfigManager.getWandStorageAutosaveIntervalSeconds() * 20L;
         autosaveTask = plugin.getServer().getScheduler().runTaskTimer(plugin, this::save, interval, interval);
     }
 
     public void stopAutosave() {
-        if (autosaveTask != null) autosaveTask.cancel();
+        if (autosaveTask != null) {
+            autosaveTask.cancel();
+        }
     }
 
     public void close() {
         stopAutosave();
         save();
-        if (dataSource != null) dataSource.close();
+        if (dataSource != null) {
+            dataSource.close();
+        }
     }
 
     public Collection<WandStorage> getAllStorages() {

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
@@ -3,7 +3,7 @@ package dev.heypr.buildersWand.managers;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import dev.heypr.buildersWand.BuildersWand;
-import org.bukkit.entity.Player;
+import dev.heypr.buildersWand.api.Wand;
 
 import java.io.File;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class WandStorageManager {
 
     private BuildersWand plugin;
-    private ConcurrentHashMap<Player, WandStorage> storage = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<Wand, WandStorage> storage = new ConcurrentHashMap<>();
     private final HikariDataSource dataSource;
 
     public WandStorageManager(BuildersWand plugin) {
@@ -44,8 +44,8 @@ public class WandStorageManager {
         // implement sql storage, loading from db to storage map in memory
     }
 
-    public synchronized WandStorage getStorage(Player player) {
-        return storage.get(player);
+    public synchronized WandStorage getStorage(Wand wand) {
+        return storage.get(wand);
     }
 
     public void save() {

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
@@ -23,8 +23,11 @@ public class WandStorageManager {
     private final BuildersWand plugin;
     private final WandStorageSerializer serializer = new WandStorageSerializer();
     private final ConcurrentHashMap<String, WandStorage> storage = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Boolean> dirtyMap = new ConcurrentHashMap<>();
     private final HikariDataSource dataSource;
     private BukkitTask autosaveTask;
+    private volatile boolean saving = false;
+    private volatile boolean shuttingDown = false;
 
     public WandStorageManager(BuildersWand plugin) {
         this.plugin = plugin;
@@ -38,12 +41,26 @@ public class WandStorageManager {
         this.dataSource = new HikariDataSource(config);
     }
 
+    public void init() {
+        createTables();
+        load();
+        startAutosave();
+    }
+
+    public void shutdown() {
+        shuttingDown = true;
+        stopAutosave();
+        waitForSaveCompletion();
+        flushDirtySync();
+        dataSource.close();
+    }
+
     public void createTables() {
         String sql = "CREATE TABLE IF NOT EXISTS wand_storage (wand_id TEXT PRIMARY KEY, content TEXT)";
-        try (Connection conn = dataSource.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.execute();
-        }
-        catch (SQLException e) {
+        } catch (SQLException e) {
             ComponentUtil.error("Failed to create tables: " + e.getMessage());
         }
     }
@@ -72,41 +89,99 @@ public class WandStorageManager {
         return wand == null ? null : storage.computeIfAbsent(wand.getId(), k -> new WandStorage(wand));
     }
 
-    public void save() {
+    public void save(Wand wand) {
+        if (shuttingDown) return;
+        dirtyMap.put(wand.getId(), true);
+    }
+
+    private void flushDirty() {
+        if (saving || dirtyMap.isEmpty()) return;
+
+        saving = true;
+
         try (Connection conn = dataSource.getConnection();
-             PreparedStatement stmt = conn.prepareStatement("INSERT OR REPLACE INTO wand_storage (wand_id, content) VALUES (?, ?)")) {
-            for (Map.Entry<String, WandStorage> entry : storage.entrySet()) {
-                String json = serializer.serializeMap(entry.getValue().getAllContent());
-                stmt.setString(1, entry.getKey());
+             PreparedStatement stmt = conn.prepareStatement(
+                     "INSERT OR REPLACE INTO wand_storage (wand_id, content) VALUES (?, ?)")) {
+
+            for (String wandId : dirtyMap.keySet()) {
+                WandStorage ws = storage.get(wandId);
+                if (ws == null) continue;
+
+                String json = serializer.serializeMap(ws.getAllContent());
+
+                stmt.setString(1, wandId);
                 stmt.setString(2, json);
                 stmt.addBatch();
             }
+
             stmt.executeBatch();
+            dirtyMap.clear();
+
         }
         catch (SQLException e) {
-            ComponentUtil.error("Failed to save storage: " + e.getMessage());
+            ComponentUtil.error("Failed to flush dirty storage: " + e.getMessage());
+        }
+        finally {
+            saving = false;
+        }
+    }
+
+    private void flushDirtySync() {
+        if (dirtyMap.isEmpty()) return;
+
+        saving = true;
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(
+                     "INSERT OR REPLACE INTO wand_storage (wand_id, content) VALUES (?, ?)")) {
+
+            for (String wandId : dirtyMap.keySet()) {
+                WandStorage ws = storage.get(wandId);
+                if (ws == null) continue;
+
+                String json = serializer.serializeMap(ws.getAllContent());
+
+                stmt.setString(1, wandId);
+                stmt.setString(2, json);
+                stmt.addBatch();
+            }
+
+            stmt.executeBatch();
+            dirtyMap.clear();
+
+        } catch (SQLException e) {
+            ComponentUtil.error("Failed to flush dirty storage (sync): " + e.getMessage());
+        } finally {
+            saving = false;
+        }
+    }
+
+    private void waitForSaveCompletion() {
+        while (saving) {
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException ignored) {
+            }
         }
     }
 
     public void startAutosave() {
-        if (!ConfigManager.isWandStorageAutosaveEnabled()) {
-            return;
-        }
+        if (!ConfigManager.isWandStorageAutosaveEnabled()) return;
+
         long interval = ConfigManager.getWandStorageAutosaveIntervalSeconds() * 20L;
-        autosaveTask = plugin.getServer().getScheduler().runTaskTimer(plugin, this::save, interval, interval);
+
+        autosaveTask = plugin.getServer().getScheduler().runTaskTimerAsynchronously(
+                plugin,
+                this::flushDirty,
+                interval,
+                interval
+        );
     }
 
     public void stopAutosave() {
         if (autosaveTask != null) {
             autosaveTask.cancel();
-        }
-    }
-
-    public void close() {
-        stopAutosave();
-        save();
-        if (dataSource != null) {
-            dataSource.close();
+            autosaveTask = null;
         }
     }
 

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageManager.java
@@ -4,57 +4,108 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import dev.heypr.buildersWand.BuildersWand;
 import dev.heypr.buildersWand.api.Wand;
+import dev.heypr.buildersWand.managers.io.ConfigManager;
+import dev.heypr.buildersWand.utility.ComponentUtil;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.io.File;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WandStorageManager {
 
-    private BuildersWand plugin;
-    private ConcurrentHashMap<Wand, WandStorage> storage = new ConcurrentHashMap<>();
+    private final BuildersWand plugin;
+    private final WandStorageSerializer serializer = new WandStorageSerializer();
+    private final ConcurrentHashMap<String, WandStorage> storage = new ConcurrentHashMap<>();
     private final HikariDataSource dataSource;
+    private BukkitTask autosaveTask;
 
     public WandStorageManager(BuildersWand plugin) {
         this.plugin = plugin;
-        File dataFolder = BuildersWand.getInstance().getDataFolder();
-        if (!dataFolder.exists()) {
-            dataFolder.mkdirs();
-        }
-
-        File dbFile = new File(dataFolder, "data.db");
-
+        File dataFolder = plugin.getDataFolder();
+        if (!dataFolder.exists()) dataFolder.mkdirs();
         HikariConfig config = new HikariConfig();
-        config.setJdbcUrl("jdbc:sqlite:" + dbFile.getAbsolutePath());
+        config.setJdbcUrl("jdbc:sqlite:" + new File(dataFolder, "data.db").getAbsolutePath());
         config.setDriverClassName("org.sqlite.JDBC");
-        config.setPoolName("WandStoragePool");
         config.setMaximumPoolSize(1);
-        config.setConnectionTestQuery("SELECT 1");
-
         config.addDataSourceProperty("journal_mode", "WAL");
-        config.addDataSourceProperty("synchronous", "NORMAL");
-
         this.dataSource = new HikariDataSource(config);
     }
 
     public void createTables() {
-        // create tables for sql storage if it doesn't exist.
+        String sql = "CREATE TABLE IF NOT EXISTS wand_storage (wand_id TEXT PRIMARY KEY, content TEXT)";
+        try (Connection conn = dataSource.getConnection(); PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.execute();
+        }
+        catch (SQLException e) {
+            ComponentUtil.error("Failed to create tables: " + e.getMessage());
+        }
     }
 
     public void load() {
-        // implement sql storage, loading from db to storage map in memory
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("SELECT wand_id, content FROM wand_storage");
+             ResultSet rs = stmt.executeQuery()) {
+            while (rs.next()) {
+                String wandId = rs.getString("wand_id");
+                String json = rs.getString("content");
+                Wand wand = WandManager.getWandConfig(wandId);
+                if (wand != null) {
+                    WandStorage ws = storage.computeIfAbsent(wandId, k -> new WandStorage(wand));
+                    Map<Integer, ItemStack> items = serializer.deserializeMap(json);
+                    items.forEach(ws::setItem);
+                }
+            }
+        }
+        catch (SQLException e) {
+            ComponentUtil.error("Failed to load storage: " + e.getMessage());
+        }
     }
 
     public synchronized WandStorage getStorage(Wand wand) {
-        return storage.get(wand);
+        return wand == null ? null : storage.computeIfAbsent(wand.getId(), k -> new WandStorage(wand));
     }
 
     public void save() {
-        // implement sql storage, saving storage map in memory to db
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement stmt = conn.prepareStatement("INSERT OR REPLACE INTO wand_storage (wand_id, content) VALUES (?, ?)")) {
+            for (Map.Entry<String, WandStorage> entry : storage.entrySet()) {
+                String json = serializer.serializeMap(entry.getValue().getAllContent());
+                stmt.setString(1, entry.getKey());
+                stmt.setString(2, json);
+                stmt.addBatch();
+            }
+            stmt.executeBatch();
+        }
+        catch (SQLException e) {
+            ComponentUtil.error("Failed to save storage: " + e.getMessage());
+        }
+    }
+
+    public void startAutosave() {
+        if (!ConfigManager.isWandStorageAutosaveEnabled()) return;
+        long interval = ConfigManager.getWandStorageAutosaveIntervalSeconds() * 20L;
+        autosaveTask = plugin.getServer().getScheduler().runTaskTimer(plugin, this::save, interval, interval);
+    }
+
+    public void stopAutosave() {
+        if (autosaveTask != null) autosaveTask.cancel();
     }
 
     public void close() {
-        if (dataSource != null && !dataSource.isClosed()) {
-            dataSource.close();
-        }
+        stopAutosave();
+        save();
+        if (dataSource != null) dataSource.close();
+    }
+
+    public Collection<WandStorage> getAllStorages() {
+        return storage.values();
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageSerializer.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/WandStorageSerializer.java
@@ -1,0 +1,50 @@
+package dev.heypr.buildersWand.managers;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import dev.heypr.buildersWand.utility.ComponentUtil;
+import org.apache.commons.codec.binary.Base64;
+import org.bukkit.inventory.ItemStack;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WandStorageSerializer {
+
+    private final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    public String serializeMap(Map<Integer, ItemStack> content) {
+        HashMap<Integer, String> encodedMap = new HashMap<>();
+        for (Map.Entry<Integer, ItemStack> entry : content.entrySet()) {
+            if (entry.getValue() == null || entry.getValue().getType().isAir()) continue;
+            try {
+                byte[] serialized = entry.getValue().serializeAsBytes();
+                encodedMap.put(entry.getKey(), Base64.encodeBase64String(serialized));
+            }
+            catch (Exception e) {
+                ComponentUtil.error("Failed to serialize item in slot " + entry.getKey() + ": " + e.getMessage());
+            }
+        }
+        return gson.toJson(encodedMap);
+    }
+
+    public Map<Integer, ItemStack> deserializeMap(String json) {
+        HashMap<Integer, ItemStack> loadedItems = new HashMap<>();
+        try {
+            Type hashMapType = new TypeToken<HashMap<Integer, String>>() {}.getType();
+            HashMap<Integer, String> map = gson.fromJson(json, hashMapType);
+            if (map == null) return loadedItems;
+            for (Map.Entry<Integer, String> entry : map.entrySet()) {
+                byte[] decoded = Base64.decodeBase64(entry.getValue());
+                ItemStack deserialized = ItemStack.deserializeBytes(decoded);
+                loadedItems.put(entry.getKey(), deserialized);
+            }
+        }
+        catch (Exception e) {
+            ComponentUtil.error("An error occurred while deserializing wand storage: " + e.getMessage());
+        }
+        return loadedItems;
+    }
+}

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/io/ConfigManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/io/ConfigManager.java
@@ -3,7 +3,7 @@ package dev.heypr.buildersWand.managers.io;
 import dev.heypr.buildersWand.BuildersWand;
 import dev.heypr.buildersWand.Updater;
 import dev.heypr.buildersWand.api.Wand;
-import dev.heypr.buildersWand.utility.Util;
+import dev.heypr.buildersWand.utility.ComponentUtil;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.configuration.ConfigurationSection;
@@ -33,10 +33,10 @@ public class ConfigManager {
         plugin.saveDefaultConfig();
         String fileVersion = plugin.getConfig().getString("config_version", "unknown");
         if (!fileVersion.equals(CURRENT_VERSION)) {
-            Util.error("OUTDATED config.yml: Expected '" + CURRENT_VERSION + "' but found '" + fileVersion + "'.");
-            Util.error("Please update your config.yml to the latest version. A default config.yml can be found on the plugin page and on GitHub. If you need help, please get in touch via the support Discord.");
+            ComponentUtil.error("OUTDATED config.yml: Expected '" + CURRENT_VERSION + "' but found '" + fileVersion + "'.");
+            ComponentUtil.error("Please update your config.yml to the latest version. A default config.yml can be found on the plugin page and on GitHub. If you need help, please get in touch via the support Discord.");
         }
-        Util.debug("Starting ConfigManager load sequence...");
+        ComponentUtil.debug("Starting ConfigManager load sequence...");
         if (BuildersWand.getRecipeManager() != null) {
             BuildersWand.getRecipeManager().unregisterRecipes();
         }
@@ -54,7 +54,7 @@ public class ConfigManager {
         updaterIntervalMinutes = config.getLong("updater.checkIntervalMinutes", 60L);
         updaterNotifyConsole = config.getBoolean("updater.notify.console", true);
         updaterNotifyInGame = config.getBoolean("updater.notify.ingame", true);
-        Util.PREFIX = MessageManager.getRegularMessage(MessageManager.Messages.PREFIX);
+        ComponentUtil.PREFIX = MessageManager.getRegularMessage(MessageManager.Messages.PREFIX);
     }
 
     public static List<Wand> loadWandConfigs() {
@@ -63,7 +63,7 @@ public class ConfigManager {
         FileConfiguration config = BuildersWand.getInstance().getConfig();
         ConfigurationSection wandsSection = config.getConfigurationSection("wands");
         if (wandsSection == null) {
-            Util.debug("Critical: 'wands' section is missing from config.yml!");
+            ComponentUtil.debug("Critical: 'wands' section is missing from config.yml!");
             return wandList;
         }
         for (String wandId : wandsSection.getKeys(false)) {
@@ -90,7 +90,7 @@ public class ConfigManager {
                     breakSound = Sound.valueOf(breakSoundName);
                 }
                 catch (Exception e) {
-                    Util.debug("Invalid break sound for wand '" + wandId + "': " + breakSoundName + ". Defaulting to ENTITY_ITEM_BREAK.");
+                    ComponentUtil.debug("Invalid break sound for wand '" + wandId + "': " + breakSoundName + ". Defaulting to ENTITY_ITEM_BREAK.");
                     breakSound = Sound.ENTITY_ITEM_BREAK;
                 }
                 String breakSoundMessage = config.getString(path + "durability.breakSound.message", "&cYour wand broke!");
@@ -119,16 +119,16 @@ public class ConfigManager {
                 List<String> recipeShape = config.getStringList(path + "craftingRecipe.shape");
                 Map<Character, Material> recipeIngredients = new HashMap<>();
                 if (craftingRecipeEnabled) {
-                    Util.debug("Loading recipe for wand " + wandId + "...");
+                    ComponentUtil.debug("Loading recipe for wand " + wandId + "...");
                     recipeShape = config.getStringList(path + "craftingRecipe.shape");
                     if (recipeShape.isEmpty() || recipeShape.size() > 3 || recipeShape.stream().anyMatch(row -> row.length() > 3)) {
-                        Util.error("Wand " + wandId + " has an invalid recipe shape. Disabling crafting.");
+                        ComponentUtil.error("Wand " + wandId + " has an invalid recipe shape. Disabling crafting.");
                         craftingRecipeEnabled = false;
                     }
                     else {
                         ConfigurationSection ingredientsSection = config.getConfigurationSection(path + "craftingRecipe.ingredients");
                         if (ingredientsSection == null) {
-                            Util.error("Wand " + wandId + " has no ingredients defined. Disabling crafting.");
+                            ComponentUtil.error("Wand " + wandId + " has no ingredients defined. Disabling crafting.");
                             craftingRecipeEnabled = false;
                         }
                         else {
@@ -139,11 +139,11 @@ public class ConfigManager {
                                     if (materialName != null) {
                                         Material mat = Material.valueOf(materialName.toUpperCase());
                                         recipeIngredients.put(ingredientChar, mat);
-                                        Util.debug("Registered ingredient: " + ingredientChar + " -> " + mat.name());
+                                        ComponentUtil.debug("Registered ingredient: " + ingredientChar + " -> " + mat.name());
                                     }
                                 }
                                 catch (IllegalArgumentException e) {
-                                    Util.error("Wand " + wandId + " invalid ingredient: " + materialName);
+                                    ComponentUtil.error("Wand " + wandId + " invalid ingredient: " + materialName);
                                     craftingRecipeEnabled = false;
                                     break;
                                 }
@@ -161,7 +161,7 @@ public class ConfigManager {
                 wandList.add(wand);
             }
             catch (Exception e) {
-                Util.error("Failed to load wand: " + wandId);
+                ComponentUtil.error("Failed to load wand: " + wandId);
             }
         }
         return wandList;

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/io/ConfigManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/io/ConfigManager.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 public class ConfigManager {
-    private static final String CURRENT_VERSION = "1.5.0";
+    private static final String CURRENT_VERSION = "1.6.0";
     private static final Map<String, Wand> wandConfigs = new HashMap<>();
     private static boolean placementQueueEnabled;
     private static boolean fireWandBlockPlaceEvent;
@@ -27,6 +27,9 @@ public class ConfigManager {
     private static boolean updaterNotifyInGame;
     private static int maxBlocksPerTick;
     private static long updaterIntervalMinutes;
+    private static boolean wandStorageEnabled;
+    private static boolean wandStorageAutosaveEnabled;
+    private static long wandStorageAutosaveIntervalSeconds;
 
     public static void load() {
         BuildersWand plugin = BuildersWand.getInstance();
@@ -52,10 +55,13 @@ public class ConfigManager {
         debugModeEnabled = config.getBoolean("debug", false);
         updaterEnabled = config.getBoolean("updater.enabled", true);
         updaterIntervalMinutes = config.getLong("updater.checkIntervalMinutes", 60L);
-        updaterNotifyConsole = config.getBoolean("updater.notify.console", true);
-        updaterNotifyInGame = config.getBoolean("updater.notify.ingame", true);
-        ComponentUtil.PREFIX = MessageManager.getRegularMessage(MessageManager.Messages.PREFIX);
-    }
+         updaterNotifyConsole = config.getBoolean("updater.notify.console", true);
+         updaterNotifyInGame = config.getBoolean("updater.notify.ingame", true);
+         wandStorageEnabled = config.getBoolean("wandStorage.enabled", true);
+         wandStorageAutosaveEnabled = config.getBoolean("wandStorage.autosave.enabled", true);
+         wandStorageAutosaveIntervalSeconds = config.getLong("wandStorage.autosave.intervalSeconds", 300L);
+         ComponentUtil.PREFIX = MessageManager.getRegularMessage(MessageManager.Messages.PREFIX);
+     }
 
     public static List<Wand> loadWandConfigs() {
         wandConfigs.clear();
@@ -217,5 +223,17 @@ public class ConfigManager {
 
     public static boolean notifyUpdateInGame() {
         return updaterNotifyInGame;
+    }
+
+    public static boolean isWandStorageEnabled() {
+        return wandStorageEnabled;
+    }
+
+    public static boolean isWandStorageAutosaveEnabled() {
+        return wandStorageAutosaveEnabled;
+    }
+
+    public static long getWandStorageAutosaveIntervalSeconds() {
+        return wandStorageAutosaveIntervalSeconds;
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/io/MessageManager.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/managers/io/MessageManager.java
@@ -2,7 +2,7 @@ package dev.heypr.buildersWand.managers.io;
 
 import dev.heypr.buildersWand.BuildersWand;
 import dev.heypr.buildersWand.api.Wand;
-import dev.heypr.buildersWand.utility.Util;
+import dev.heypr.buildersWand.utility.ComponentUtil;
 import net.kyori.adventure.text.TextComponent;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -26,13 +26,13 @@ public class MessageManager {
             loadMessagesFromFile();
             String fileVersion = messages.getString("config_version", "unknown");
             if (!fileVersion.equals(CURRENT_VERSION)) {
-                Util.error("OUTDATED messages.yml: Expected '" + CURRENT_VERSION + "' but found '" + fileVersion + "'.");
-                Util.error("Please update your messages.yml to the latest version. A default messages.yml can be found on the plugin page and on GitHub.");
+                ComponentUtil.error("OUTDATED messages.yml: Expected '" + CURRENT_VERSION + "' but found '" + fileVersion + "'.");
+                ComponentUtil.error("Please update your messages.yml to the latest version. A default messages.yml can be found on the plugin page and on GitHub.");
             }
-            Util.debug("MessageManager initialized successfully!");
+            ComponentUtil.debug("MessageManager initialized successfully!");
         }
         catch (Exception e) {
-            Util.error("Failed to initialize MessageManager: " + e.getMessage());
+            ComponentUtil.error("Failed to initialize MessageManager: " + e.getMessage());
         }
     }
 
@@ -41,16 +41,16 @@ public class MessageManager {
             throw new RuntimeException("messages.yml file not found at: " + messagesFile);
         }
         messages = YamlConfiguration.loadConfiguration(messagesFile);
-        Util.debug("Messages YAML loaded from disk");
+        ComponentUtil.debug("Messages YAML loaded from disk");
     }
 
     public static void reload() {
         try {
             initialize();
-            Util.debug("Messages reloaded successfully");
+            ComponentUtil.debug("Messages reloaded successfully");
         }
         catch (Exception e) {
-            Util.error("Failed to reload messages: " + e.getMessage());
+            ComponentUtil.error("Failed to reload messages: " + e.getMessage());
         }
     }
 
@@ -94,11 +94,11 @@ public class MessageManager {
     }
 
     public static TextComponent getPrefixedMessage(Messages message) {
-        return Util.toPrefixedComponent(getMessage(message));
+        return ComponentUtil.toPrefixedComponent(getMessage(message));
     }
 
     public static TextComponent getRegularMessage(Messages message) {
-        return Util.toComponent(getMessage(message));
+        return ComponentUtil.toComponent(getMessage(message));
     }
 
     private static String getWandValue(Wand wand, String value) {
@@ -151,12 +151,12 @@ public class MessageManager {
 
     public static String getMessage(Messages message) {
         if (messages == null) {
-            Util.error("MessageManager not initialized! Get in touch via Discord to resolve this!");
+            ComponentUtil.error("MessageManager not initialized! Get in touch via Discord to resolve this!");
             return "&4Missing: &c[" + message.getKey() + "]";
         }
         String msg = messages.getString(message.getKey());
         if (msg == null) {
-            Util.error("Message key not found: '" + message.getKey() + "'! Using default value.");
+            ComponentUtil.error("Message key not found: '" + message.getKey() + "'! Using default value.");
             return message.getDefaultValue();
         }
         return msg;
@@ -171,7 +171,7 @@ public class MessageManager {
         String msg = getMessage(message);
 
         if (placeholders.length % 2 != 0) {
-            Util.error("Invalid placeholder count for: " + message.getKey());
+            ComponentUtil.error("Invalid placeholder count for: " + message.getKey());
             return msg;
         }
         for (int i = 0; i < placeholders.length; i += 2) {
@@ -186,76 +186,76 @@ public class MessageManager {
         if (player == null) {
             return;
         }
-        player.sendActionBar(Util.toPrefixedComponent(getMessage(message)));
+        player.sendActionBar(ComponentUtil.toPrefixedComponent(getMessage(message)));
     }
 
     public static void sendActionBar(Player player, Messages message, String key, String value) {
         if (player == null) {
             return;
         }
-        player.sendActionBar(Util.toPrefixedComponent(getMessage(message, key, value)));
+        player.sendActionBar(ComponentUtil.toPrefixedComponent(getMessage(message, key, value)));
     }
 
     public static void sendActionBar(Player player, Messages message, Object... placeholders) {
         if (player == null) {
             return;
         }
-        player.sendActionBar(Util.toPrefixedComponent(getMessage(message, placeholders)));
+        player.sendActionBar(ComponentUtil.toPrefixedComponent(getMessage(message, placeholders)));
     }
 
     public static void sendMessage(Player player, Messages message) {
         if (player == null) {
             return;
         }
-        player.sendMessage(Util.toPrefixedComponent(getMessage(message)));
+        player.sendMessage(ComponentUtil.toPrefixedComponent(getMessage(message)));
     }
 
     public static void sendMessage(Player player, Messages message, String key, String value) {
         if (player == null) {
             return;
         }
-        player.sendMessage(Util.toPrefixedComponent(getMessage(message, key, value)));
+        player.sendMessage(ComponentUtil.toPrefixedComponent(getMessage(message, key, value)));
     }
 
     public static void sendMessage(Player player, Messages message, Object... placeholders) {
         if (player == null) {
             return;
         }
-        player.sendMessage(Util.toPrefixedComponent(getMessage(message, placeholders)));
+        player.sendMessage(ComponentUtil.toPrefixedComponent(getMessage(message, placeholders)));
     }
 
     public static void sendMessage(CommandSender sender, Messages message) {
         if (sender == null) {
             return;
         }
-        sender.sendMessage(Util.toPrefixedComponent(getMessage(message)));
+        sender.sendMessage(ComponentUtil.toPrefixedComponent(getMessage(message)));
     }
 
     public static void sendMessage(CommandSender sender, Messages message, String key, String value) {
         if (sender == null) {
             return;
         }
-        sender.sendMessage(Util.toPrefixedComponent(getMessage(message, key, value)));
+        sender.sendMessage(ComponentUtil.toPrefixedComponent(getMessage(message, key, value)));
     }
 
     public static void sendMessage(CommandSender sender, Messages message, Object... placeholders) {
         if (sender == null) {
             return;
         }
-        sender.sendMessage(Util.toPrefixedComponent(getMessage(message, placeholders)));
+        sender.sendMessage(ComponentUtil.toPrefixedComponent(getMessage(message, placeholders)));
     }
 
     public static void sendMessage(CommandSender sender, Messages message, Wand wand) {
         if (sender == null) {
             return;
         }
-        sender.sendMessage(Util.toPrefixedComponent(getWandMessage(message, wand)));
+        sender.sendMessage(ComponentUtil.toPrefixedComponent(getWandMessage(message, wand)));
     }
 
     public static void sendMessage(Player player, Messages message, Wand wand) {
         if (player == null) {
             return;
         }
-        player.sendMessage(Util.toPrefixedComponent(getWandSenderMessage(message, wand, player)));
+        player.sendMessage(ComponentUtil.toPrefixedComponent(getWandSenderMessage(message, wand, player)));
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/BlockFinderUtil.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/BlockFinderUtil.java
@@ -1,4 +1,4 @@
-package dev.heypr.buildersWand.managers;
+package dev.heypr.buildersWand.utility;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -6,7 +6,7 @@ import org.bukkit.block.BlockFace;
 
 import java.util.*;
 
-public class BlockFinder {
+public class BlockFinderUtil {
     public static final Set<Material> REPLACEABLE = EnumSet.of(
             Material.AIR,
             Material.CAVE_AIR,

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/ComponentUtil.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/ComponentUtil.java
@@ -10,7 +10,8 @@ import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 
 import java.util.Objects;
 
-public class Util {
+public class ComponentUtil {
+
     public static TextComponent PREFIX;
 
     public static TextComponent toComponent(String string) {
@@ -29,14 +30,14 @@ public class Util {
         if (!ConfigManager.getDebugMode()) {
             return;
         }
-        BuildersWand.getInstance().getComponentLogger().info(Util.toComponent("[DEBUG] " + string));
+        BuildersWand.getInstance().getComponentLogger().info(ComponentUtil.toComponent("[DEBUG] " + string));
     }
 
     public static void log(String string) {
-        BuildersWand.getInstance().getComponentLogger().info(Util.toComponent(string));
+        BuildersWand.getInstance().getComponentLogger().info(ComponentUtil.toComponent(string));
     }
 
     public static void error(String string) {
-        BuildersWand.getInstance().getComponentLogger().error(Util.toComponent(string));
+        BuildersWand.getInstance().getComponentLogger().error(ComponentUtil.toComponent(string));
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/InventoryUtil.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/InventoryUtil.java
@@ -1,0 +1,39 @@
+package dev.heypr.buildersWand.utility;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class InventoryUtil {
+
+    public static int getItemCount(Player player, Material material) {
+        int count = 0;
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item != null && item.getType() == material) {
+                count += item.getAmount();
+            }
+        }
+        // todo: add wandstorage inventory checking here.
+        return count;
+    }
+
+    public static void removeItems(Player player, Material material, int amount) {
+        int remaining = amount;
+        for (ItemStack item : player.getInventory().getContents()) {
+            if (item == null || item.getType() != material) {
+                continue;
+            }
+            int amt = item.getAmount();
+            if (amt <= remaining) {
+                remaining -= amt;
+                item.setAmount(0);
+            }
+            else {
+                item.setAmount(amt - remaining);
+                break;
+            }
+        }
+        // todo: mark if item is being taken from the player's inventory or the wand storage and place accordingly.
+        // todo: put overflowing items into wand storage.
+    }
+}

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/InventoryUtil.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/InventoryUtil.java
@@ -1,8 +1,16 @@
 package dev.heypr.buildersWand.utility;
 
+import dev.heypr.buildersWand.BuildersWand;
+import dev.heypr.buildersWand.managers.WandStorage;
+import dev.heypr.buildersWand.managers.WandStorageManager;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class InventoryUtil {
 
@@ -13,7 +21,16 @@ public class InventoryUtil {
                 count += item.getAmount();
             }
         }
-        // todo: add wandstorage inventory checking here.
+        WandStorageManager manager = BuildersWand.getStorageManager();
+        if (manager != null) {
+            for (WandStorage storage : manager.getAllStorages()) {
+                for (ItemStack item : storage.getItems()) {
+                    if (item != null && item.getType() == material) {
+                        count += item.getAmount();
+                    }
+                }
+            }
+        }
         return count;
     }
 
@@ -33,7 +50,68 @@ public class InventoryUtil {
                 break;
             }
         }
-        // todo: mark if item is being taken from the player's inventory or the wand storage and place accordingly.
-        // todo: put overflowing items into wand storage.
+        if (remaining <= 0) return;
+        WandStorageManager manager = BuildersWand.getStorageManager();
+        if (manager != null) {
+            for (WandStorage storage : manager.getAllStorages()) {
+                if (remaining <= 0) break;
+                remaining -= storage.removeItems(material, remaining);
+            }
+        }
+    }
+
+    public static void returnItems(Player player, List<ItemStack> items) {
+        if (items == null || items.isEmpty() || player.getGameMode().isInvulnerable()) {
+            return;
+        }
+        List<ItemStack> toDrop = new ArrayList<>();
+        for (ItemStack item : items) {
+            if (item == null || item.getType().isAir() || item.getAmount() <= 0) continue;
+
+            Map<Integer, ItemStack> leftover = player.getInventory().addItem(item);
+            if (!leftover.isEmpty()) {
+                toDrop.addAll(leftover.values());
+            }
+        }
+        if (toDrop.isEmpty()) return;
+        tryAddToStorage(player, toDrop);
+    }
+
+    private static void tryAddToStorage(Player player, List<ItemStack> items) {
+        WandStorageManager manager = BuildersWand.getStorageManager();
+        if (manager == null) {
+            dropItems(player, items);
+            return;
+        }
+
+        List<ItemStack> notStored = new ArrayList<>();
+        for (ItemStack item : items) {
+            if (item == null || item.getType().isAir() || item.getAmount() <= 0) continue;
+            boolean stored = false;
+            for (WandStorage storage : manager.getAllStorages()) {
+                int maxIndex = storage.getAllContent().keySet().stream()
+                        .max(Integer::compareTo)
+                        .orElse(-1);
+
+                storage.setItem(maxIndex + 1, item.clone());
+                stored = true;
+                break;
+            }
+            if (!stored) {
+                notStored.add(item);
+            }
+        }
+        if (!notStored.isEmpty()) {
+            dropItems(player, notStored);
+        }
+    }
+
+    private static void dropItems(Player player, List<ItemStack> items) {
+        Location location = player.getLocation();
+        for (ItemStack item : items) {
+            if (item != null && !item.getType().isAir() && item.getAmount() > 0) {
+                player.getWorld().dropItemNaturally(location, item);
+            }
+        }
     }
 }

--- a/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/InventoryUtil.java
+++ b/BuildersWand/src/main/java/dev/heypr/buildersWand/utility/InventoryUtil.java
@@ -1,6 +1,7 @@
 package dev.heypr.buildersWand.utility;
 
 import dev.heypr.buildersWand.BuildersWand;
+import dev.heypr.buildersWand.api.Wand;
 import dev.heypr.buildersWand.managers.WandStorage;
 import dev.heypr.buildersWand.managers.WandStorageManager;
 import org.bukkit.Location;
@@ -14,7 +15,7 @@ import java.util.Map;
 
 public class InventoryUtil {
 
-    public static int getItemCount(Player player, Material material) {
+    public static int getItemCount(Player player, Material material, Wand wand) {
         int count = 0;
         for (ItemStack item : player.getInventory().getContents()) {
             if (item != null && item.getType() == material) {
@@ -23,18 +24,17 @@ public class InventoryUtil {
         }
         WandStorageManager manager = BuildersWand.getStorageManager();
         if (manager != null) {
-            for (WandStorage storage : manager.getAllStorages()) {
-                for (ItemStack item : storage.getItems()) {
-                    if (item != null && item.getType() == material) {
-                        count += item.getAmount();
-                    }
+            WandStorage storage = manager.getStorage(wand);
+            for (ItemStack item : storage.getItems()) {
+                if (item != null && item.getType() == material) {
+                    count += item.getAmount();
                 }
             }
         }
         return count;
     }
 
-    public static void removeItems(Player player, Material material, int amount) {
+    public static void removeItems(Player player, Material material, int amount, Wand wand) {
         int remaining = amount;
         for (ItemStack item : player.getInventory().getContents()) {
             if (item == null || item.getType() != material) {
@@ -53,14 +53,14 @@ public class InventoryUtil {
         if (remaining <= 0) return;
         WandStorageManager manager = BuildersWand.getStorageManager();
         if (manager != null) {
-            for (WandStorage storage : manager.getAllStorages()) {
-                if (remaining <= 0) break;
-                remaining -= storage.removeItems(material, remaining);
+            WandStorage storage = manager.getStorage(wand);
+            if (storage.hasMaterial(material)) {
+                storage.removeItems(material, remaining);
             }
         }
     }
 
-    public static void returnItems(Player player, List<ItemStack> items) {
+    public static void returnItems(Player player, List<ItemStack> items, Wand wand) {
         if (items == null || items.isEmpty() || player.getGameMode().isInvulnerable()) {
             return;
         }
@@ -74,35 +74,24 @@ public class InventoryUtil {
             }
         }
         if (toDrop.isEmpty()) return;
-        tryAddToStorage(player, toDrop);
+        tryAddToStorage(player, toDrop, wand);
     }
 
-    private static void tryAddToStorage(Player player, List<ItemStack> items) {
+    private static void tryAddToStorage(Player player, List<ItemStack> items, Wand wand) {
         WandStorageManager manager = BuildersWand.getStorageManager();
         if (manager == null) {
             dropItems(player, items);
             return;
         }
 
-        List<ItemStack> notStored = new ArrayList<>();
         for (ItemStack item : items) {
             if (item == null || item.getType().isAir() || item.getAmount() <= 0) continue;
-            boolean stored = false;
-            for (WandStorage storage : manager.getAllStorages()) {
-                int maxIndex = storage.getAllContent().keySet().stream()
-                        .max(Integer::compareTo)
-                        .orElse(-1);
+            WandStorage storage = manager.getStorage(wand);
+            int maxIndex = storage.getAllContent().keySet().stream()
+                    .max(Integer::compareTo)
+                    .orElse(-1);
 
-                storage.setItem(maxIndex + 1, item.clone());
-                stored = true;
-                break;
-            }
-            if (!stored) {
-                notStored.add(item);
-            }
-        }
-        if (!notStored.isEmpty()) {
-            dropItems(player, notStored);
+            storage.setItem(maxIndex + 1, item.clone());
         }
     }
 

--- a/BuildersWand/src/main/resources/config.yml
+++ b/BuildersWand/src/main/resources/config.yml
@@ -2,7 +2,7 @@
 
 # DO NOT EDIT THIS LINE!!!
 # IT IS USED TO CHECK IF THE FILE IS OUTDATED AND NEEDS TO BE UPDATED
-config_version: 1.5.0
+config_version: 1.6.0
 
 # this isn't required for the build wand to work, but it does reduce the amount of fired events when placing blocks through the wand.
 # set to false if you want to handle block place event cancellations yourself and don't want extra events fired.
@@ -34,6 +34,12 @@ updater:
 
 # Only recommended when troubleshooting issues since it can generate a lot of log spam. defaults to false.
 debug: false
+
+wandStorage:
+  enabled: true
+  autosave:
+    enabled: true
+    intervalSeconds: 300
 
 wands:
   my_special_wand:

--- a/BuildersWand/src/main/resources/plugin.yml
+++ b/BuildersWand/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: BuildersWand
-version: '1.5.1'
+version: '1.6.0'
 description: Highly configurable, survival-friendly building wands » straw.hat on SpigotMC
 author: heypr
 main: dev.heypr.buildersWand.BuildersWand

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ updater:
 # Only recommended when troubleshooting issues since it can generate a lot of log spam. defaults to false.
 debug: false
 
+wandStorage:
+  enabled: true
+  autosave:
+    enabled: true
+    intervalSeconds: 300
+
 wands:
   my_special_wand:
     name: "&3Builders Wand"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ BuildersWand *does* feature an API, but currently there is no documentation nor 
 
 # DO NOT EDIT THIS LINE!!!
 # IT IS USED TO CHECK IF THE FILE IS OUTDATED AND NEEDS TO BE UPDATED
-config_version: 1.5.0
+config_version: 1.6.0
 
 # this isn't required for the build wand to work, but it does reduce the amount of fired events when placing blocks through the wand.
 # set to false if you want to handle block place event cancellations yourself and don't want extra events fired.

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'dev.heypr'
-version = '1.5.1'
+version = '1.6.0'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
The highlight of this update is the wand storage feature. It will allow people to use items from inside of a virtual inventory attached to the wand.
Additionally, players now have more control over their wands. A new options menu, attached to the wand and configurable by admins, allows users to adjust various parts about their wand. Configurable options include, but are not limited to:
- Wand size (with a min and mix range)
- Wand preview particles (size and quantity limited by default)
- Break sound
- Wand type
Again, this is not an exhaustive list and is only what a server admin might want to allow users to modify.
Both of these features can be enabled or disabled per wand, and will be off by default but pre-configured to reasonable values.

